### PR TITLE
Make afterReset truly optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 /dist/
+node_modules
+
+# VSCode editor settings
+.vscode

--- a/README.md
+++ b/README.md
@@ -157,11 +157,13 @@ Configuration goes in `.gmrc`, which is a JSON file with the following keys:
   `graphile-migrate reset` this will be dropped without warning, so be careful.
 - `shadowConnectionString` — optional, alternatively set `SHADOW_DATABASE_URL`
   environment variable. **Should not already exist.**
-- `rootConnectionString` — optional (defaults to "template1"), alternatively
+- `rootConnectionString` — optional, alternatively
   set `ROOT_DATABASE_URL` environment variable; this is used to connect to
   the database with superuser privileges to drop and re-create the relevant
   databases (via the `reset` command directly, or via the `commit` command for
-  the shadow database).
+  the shadow database). It defaults to "template1" if the key or environment variable
+  is not set so it may result in PG connection errors if a default PG `template1`
+  database is not available.
 - `pgSettings` — optional string-string key-value object defining settings to
   set in PostgreSQL when migrating. Useful for setting `search_path` for
   example. Beware of changing this, a full reset will use the new values which

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -185,9 +185,13 @@ export async function parseSettings(
   );
 
   await check("afterReset", async (rawAfterReset: unknown) => {
-    const afterResetArray = Array.isArray(rawAfterReset)
-      ? rawAfterReset
-      : [rawAfterReset];
+    let afterResetArray;
+    afterResetArray = !rawAfterReset ? [] : [rawAfterReset];
+
+    if (Array.isArray(rawAfterReset)) {
+      afterResetArray = rawAfterReset;
+    }
+
     for (const afterReset of afterResetArray) {
       if (afterReset && typeof afterReset === "string") {
         await fsp.stat(`${migrationsFolder}/${afterReset}`);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -185,13 +185,12 @@ export async function parseSettings(
   );
 
   await check("afterReset", async (rawAfterReset: unknown) => {
-    let afterResetArray;
-    afterResetArray = !rawAfterReset ? [] : [rawAfterReset];
-
-    if (Array.isArray(rawAfterReset)) {
-      afterResetArray = rawAfterReset;
+    if (!rawAfterReset) {
+      return;
     }
-
+    const afterResetArray = Array.isArray(rawAfterReset)
+      ? rawAfterReset
+      : [rawAfterReset];
     for (const afterReset of afterResetArray) {
       if (afterReset && typeof afterReset === "string") {
         await fsp.stat(`${migrationsFolder}/${afterReset}`);


### PR DESCRIPTION
Currently, if you don't set `afterReset` in `.grmc`, then you get error:

`Expected afterReset to contain an array of strings or command specs; received '[undefined]'`

Since documentation says this parameter is optional, I prepared PR which handles a situation when the parameter is not present in `.grmc`.