### PR TITLE
Overhaul actions

### DIFF
--- a/__tests__/__snapshots__/settings.test.ts.snap
+++ b/__tests__/__snapshots__/settings.test.ts.snap
@@ -1,0 +1,115 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`actions parses SQL actions 1`] = `
+Object {
+  "afterAllMigrations": Array [
+    Object {
+      "_": "sql",
+      "file": "bar.sql",
+    },
+    Object {
+      "_": "sql",
+      "file": "baz.sql",
+    },
+  ],
+  "afterReset": Array [
+    Object {
+      "_": "sql",
+      "file": "foo.sql",
+    },
+  ],
+  "connectionString": "postgres://localhost:5432/dbname?ssl=1",
+  "databaseName": "dbname",
+  "databaseOwner": "dbname",
+  "migrationsFolder": "./migrations",
+  "placeholders": undefined,
+  "rootConnectionString": "template1",
+  "shadowConnectionString": undefined,
+  "shadowDatabaseName": undefined,
+}
+`;
+
+exports[`actions parses command actions 1`] = `
+Object {
+  "afterAllMigrations": Array [
+    Object {
+      "_": "command",
+      "command": "pg_dump --schema-only",
+    },
+    Object {
+      "_": "command",
+      "command": "graphile-worker --once",
+    },
+  ],
+  "afterReset": Array [],
+  "connectionString": "postgres://localhost:5432/dbname?ssl=1",
+  "databaseName": "dbname",
+  "databaseOwner": "dbname",
+  "migrationsFolder": "./migrations",
+  "placeholders": undefined,
+  "rootConnectionString": "template1",
+  "shadowConnectionString": undefined,
+  "shadowDatabaseName": undefined,
+}
+`;
+
+exports[`actions parses mixed actions 1`] = `
+Object {
+  "afterAllMigrations": Array [
+    Object {
+      "_": "sql",
+      "file": "foo.sql",
+    },
+    Object {
+      "_": "sql",
+      "file": "bar.sql",
+    },
+    Object {
+      "_": "command",
+      "command": "pg_dump --schema-only",
+    },
+    Object {
+      "_": "command",
+      "command": "graphile-worker --once",
+    },
+  ],
+  "afterReset": Array [],
+  "connectionString": "postgres://localhost:5432/dbname?ssl=1",
+  "databaseName": "dbname",
+  "databaseOwner": "dbname",
+  "migrationsFolder": "./migrations",
+  "placeholders": undefined,
+  "rootConnectionString": "template1",
+  "shadowConnectionString": undefined,
+  "shadowDatabaseName": undefined,
+}
+`;
+
+exports[`actions parses string values into SQL actions 1`] = `
+Object {
+  "afterAllMigrations": Array [
+    Object {
+      "_": "sql",
+      "file": "bar.sql",
+    },
+    Object {
+      "_": "sql",
+      "file": "baz.sql",
+    },
+  ],
+  "afterReset": Array [
+    Object {
+      "_": "sql",
+      "file": "foo.sql",
+    },
+  ],
+  "connectionString": "postgres://localhost:5432/dbname?ssl=1",
+  "databaseName": "dbname",
+  "databaseOwner": "dbname",
+  "migrationsFolder": "./migrations",
+  "placeholders": undefined,
+  "rootConnectionString": "template1",
+  "shadowConnectionString": undefined,
+  "shadowDatabaseName": undefined,
+}
+`;

--- a/__tests__/__snapshots__/settings.test.ts.snap
+++ b/__tests__/__snapshots__/settings.test.ts.snap
@@ -1,5 +1,37 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`actions is backwards-compatible with untagged command specs 1`] = `
+Object {
+  "afterAllMigrations": Array [
+    Object {
+      "_": "sql",
+      "file": "foo.sql",
+    },
+    Object {
+      "_": "sql",
+      "file": "bar.sql",
+    },
+    Object {
+      "_": "command",
+      "command": "pg_dump --schema-only",
+    },
+    Object {
+      "_": "command",
+      "command": "graphile-worker --once",
+    },
+  ],
+  "afterReset": Array [],
+  "connectionString": "postgres://localhost:5432/dbname?ssl=1",
+  "databaseName": "dbname",
+  "databaseOwner": "dbname",
+  "migrationsFolder": "./migrations",
+  "placeholders": undefined,
+  "rootConnectionString": "template1",
+  "shadowConnectionString": undefined,
+  "shadowDatabaseName": undefined,
+}
+`;
+
 exports[`actions parses SQL actions 1`] = `
 Object {
   "afterAllMigrations": Array [

--- a/__tests__/settings.test.ts
+++ b/__tests__/settings.test.ts
@@ -107,6 +107,27 @@ describe("actions", () => {
     expect(parsedSettings).toMatchSnapshot();
   });
 
+  it("is backwards-compatible with untagged command specs", async () => {
+    const parsedSettings = await parseSettings({
+      connectionString: exampleConnectionString,
+      afterAllMigrations: [
+        "foo.sql",
+        { _: "sql", file: "bar.sql" },
+        { command: "pg_dump --schema-only" } as any,
+        { _: "command", command: "graphile-worker --once" },
+      ],
+    });
+    expect(parsedSettings.afterReset).toEqual([]);
+    expect(parsedSettings.afterAllMigrations).toEqual([
+      { _: "sql", file: "foo.sql" },
+      { _: "sql", file: "bar.sql" },
+      { _: "command", command: "pg_dump --schema-only" },
+      { _: "command", command: "graphile-worker --once" },
+    ]);
+    sanitise(parsedSettings);
+    expect(parsedSettings).toMatchSnapshot();
+  });
+
   it("throws on unknown action type", async () => {
     await expect(
       parseSettings({

--- a/__tests__/settings.test.ts
+++ b/__tests__/settings.test.ts
@@ -1,0 +1,80 @@
+import { parseSettings, ParsedSettings } from "../src/settings";
+import * as path from "path";
+
+function sanitise(parsedSettings: ParsedSettings) {
+  parsedSettings.migrationsFolder =
+    "./" + path.relative(process.cwd(), parsedSettings.migrationsFolder);
+}
+
+const exampleConnectionString = "postgres://localhost:5432/dbname?ssl=1";
+it("parses basic config", async () => {
+  await parseSettings({
+    connectionString: exampleConnectionString,
+  });
+});
+
+it("throws error for missing connection string", async () => {
+  await expect(parseSettings({})).rejects.toMatchInlineSnapshot(`
+          [Error: Errors occurred during settings validation:
+          - Setting 'connectionString': Expected a string, or for DATABASE_URL envvar to be set]
+        `);
+});
+
+it("throws if shadow attempted but no shadow DB", async () => {
+  await expect(
+    parseSettings(
+      {
+        connectionString: exampleConnectionString,
+      },
+      true
+    )
+  ).rejects.toMatchInlineSnapshot(`
+          [Error: Errors occurred during settings validation:
+          - Setting 'shadowConnectionString': Expected a string, or for TEST_DATABASE_URL to be set
+          - Could not determine the shadow database name, please ensure shadowConnectionString includes the database name.]
+        `);
+});
+
+describe("actions", () => {
+  it("parses string values into SQL actions", async () => {
+    const parsedSettings = await parseSettings({
+      connectionString: exampleConnectionString,
+      afterReset: "foo.sql",
+      afterAllMigrations: ["bar.sql", "baz.sql"],
+    });
+    expect(parsedSettings.afterReset).toEqual([{ _: "sql", file: "foo.sql" }]);
+    expect(parsedSettings.afterAllMigrations).toEqual([
+      { _: "sql", file: "bar.sql" },
+      { _: "sql", file: "baz.sql" },
+    ]);
+    sanitise(parsedSettings);
+    expect(parsedSettings).toMatchInlineSnapshot(`
+      Object {
+        "afterAllMigrations": Array [
+          Object {
+            "_": "sql",
+            "file": "bar.sql",
+          },
+          Object {
+            "_": "sql",
+            "file": "baz.sql",
+          },
+        ],
+        "afterReset": Array [
+          Object {
+            "_": "sql",
+            "file": "foo.sql",
+          },
+        ],
+        "connectionString": "postgres://localhost:5432/dbname?ssl=1",
+        "databaseName": "dbname",
+        "databaseOwner": "dbname",
+        "migrationsFolder": "./migrations",
+        "placeholders": undefined,
+        "rootConnectionString": "template1",
+        "shadowConnectionString": undefined,
+        "shadowDatabaseName": undefined,
+      }
+    `);
+  });
+});

--- a/__tests__/settings.test.ts
+++ b/__tests__/settings.test.ts
@@ -106,4 +106,21 @@ describe("actions", () => {
     sanitise(parsedSettings);
     expect(parsedSettings).toMatchSnapshot();
   });
+
+  it("throws on unknown action type", async () => {
+    await expect(
+      parseSettings({
+        connectionString: exampleConnectionString,
+        afterAllMigrations: [
+          "foo.sql",
+          { _: "sql", file: "bar.sql" },
+          { _: "unknown_value", command: "pg_dump --schema-only" } as any,
+          { _: "command", command: "graphile-worker --once" },
+        ],
+      })
+    ).rejects.toMatchInlineSnapshot(`
+            [Error: Errors occurred during settings validation:
+            - Setting 'afterAllMigrations': Action spec of type 'unknown_value' not supported; perhaps you need to upgrade?]
+          `);
+  });
 });

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -46,28 +46,30 @@ export async function executeActions(
         }
       );
     } else if (isCommandActionSpec(actionSpec)) {
-      // Run the command
-      const { stdout, stderr } = await exec(actionSpec.command, {
-        env: {
-          PATH: process.env.PATH,
-          DATABASE_URL: connectionString, // DO NOT USE THIS! It can be misleadling.
-          GM_DBURL: connectionString,
-          ...(shadow
-            ? {
-                GM_SHADOW: "1",
-              }
-            : null),
-        },
-        encoding: "utf8",
-        maxBuffer: 10 * 1024 * 1024,
-      });
-      if (stdout) {
-        // tslint:disable-next-line no-console
-        console.log(stdout);
-      }
-      if (stderr) {
-        // tslint:disable-next-line no-console
-        console.error(stderr);
+      if (actionSpec.shadow === undefined || actionSpec.shadow === shadow) {
+        // Run the command
+        const { stdout, stderr } = await exec(actionSpec.command, {
+          env: {
+            PATH: process.env.PATH,
+            DATABASE_URL: connectionString, // DO NOT USE THIS! It can be misleadling.
+            GM_DBURL: connectionString,
+            ...(shadow
+              ? {
+                  GM_SHADOW: "1",
+                }
+              : null),
+          },
+          encoding: "utf8",
+          maxBuffer: 10 * 1024 * 1024,
+        });
+        if (stdout) {
+          // tslint:disable-next-line no-console
+          console.log(stdout);
+        }
+        if (stderr) {
+          // tslint:disable-next-line no-console
+          console.error(stderr);
+        }
       }
     }
   }

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -103,7 +103,22 @@ export function makeValidateActionCallback() {
       const rawSpecArray = Array.isArray(inputValue)
         ? inputValue
         : [inputValue];
-      for (const rawSpec of rawSpecArray) {
+      for (const trueRawSpec of rawSpecArray) {
+        // This fudge is for backwards compatibility with v0.0.3
+        const isV003OrBelowCommand =
+          typeof trueRawSpec === "object" &&
+          trueRawSpec &&
+          !trueRawSpec["_"] &&
+          typeof trueRawSpec["command"] === "string";
+        if (isV003OrBelowCommand) {
+          console.warn(
+            "DEPRECATED: graphile-migrate now requires command action specs to have an `_: 'command'` property; we'll back-fill this for now, but please update your configuration"
+          );
+        }
+        const rawSpec = isV003OrBelowCommand
+          ? { _: "command", ...trueRawSpec }
+          : trueRawSpec;
+
         if (rawSpec && typeof rawSpec === "string") {
           const sqlSpec: SqlActionSpec = {
             _: "sql",

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -46,6 +46,9 @@ export async function executeActions(
     );
   }
   for (const actionSpec of actions) {
+    if (actionSpec.shadow !== undefined && actionSpec.shadow !== shadow) {
+      continue;
+    }
     if (actionSpec._ === "sql") {
       await withClient(
         connectionString,
@@ -66,30 +69,28 @@ export async function executeActions(
         }
       );
     } else if (actionSpec._ === "command") {
-      if (actionSpec.shadow === undefined || actionSpec.shadow === shadow) {
-        // Run the command
-        const { stdout, stderr } = await exec(actionSpec.command, {
-          env: {
-            PATH: process.env.PATH,
-            DATABASE_URL: connectionString, // DO NOT USE THIS! It can be misleadling.
-            GM_DBURL: connectionString,
-            ...(shadow
-              ? {
-                  GM_SHADOW: "1",
-                }
-              : null),
-          },
-          encoding: "utf8",
-          maxBuffer: 10 * 1024 * 1024,
-        });
-        if (stdout) {
-          // tslint:disable-next-line no-console
-          console.log(stdout);
-        }
-        if (stderr) {
-          // tslint:disable-next-line no-console
-          console.error(stderr);
-        }
+      // Run the command
+      const { stdout, stderr } = await exec(actionSpec.command, {
+        env: {
+          PATH: process.env.PATH,
+          DATABASE_URL: connectionString, // DO NOT USE THIS! It can be misleadling.
+          GM_DBURL: connectionString,
+          ...(shadow
+            ? {
+                GM_SHADOW: "1",
+              }
+            : null),
+        },
+        encoding: "utf8",
+        maxBuffer: 10 * 1024 * 1024,
+      });
+      if (stdout) {
+        // tslint:disable-next-line no-console
+        console.log(stdout);
+      }
+      if (stderr) {
+        // tslint:disable-next-line no-console
+        console.error(stderr);
       }
     }
   }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,30 +1,51 @@
 import { parse } from "pg-connection-string";
 import { makeValidateActionCallback } from "./actions";
 
-export interface CommandActionSpec {
-  command: string;
+export interface ActionSpec {
+  _: string;
   shadow?: boolean;
+}
+
+export interface CommandActionSpec extends ActionSpec {
+  _: "command";
+  command: string;
 }
 
 export type Actions = string | Array<string | CommandActionSpec>;
 
-export function isCommandActionSpec(o: unknown): o is CommandActionSpec {
-  if (!o || typeof o !== "object") {
-    return false;
-  }
-  const obj = o!;
-  if (typeof obj["command"] !== "string") {
+export function isActionSpec(o: unknown): o is ActionSpec {
+  if (!(typeof o === "object" && o && typeof o["_"] === "string")) {
     return false;
   }
 
-  // After here it's definitely a command action spec; but we should still
-  // validate the other properties.
+  // After here it's definitely an action spec; but we should still validate the
+  // other properties.
 
-  if ("shadow" in obj && typeof obj["shadow"] !== "boolean") {
+  if ("shadow" in o && typeof o["shadow"] !== "boolean") {
     throw new Error(
-      `Command action has 'shadow' property of type '${typeof obj[
+      `'${o["_"]}' action has 'shadow' property of type '${typeof o[
         "shadow"
       ]}'; expected 'boolean' (or not set)`
+    );
+  }
+
+  return true;
+}
+
+export function isCommandActionSpec(o: unknown): o is CommandActionSpec {
+  if (!isActionSpec(o)) {
+    return false;
+  }
+  if (o._ !== "command") {
+    return false;
+  }
+
+  // Validations
+  if (typeof o["command"] !== "string") {
+    throw new Error(
+      `Command action has 'command' property of type '${typeof o[
+        "command"
+      ]}'; expected 'string'`
     );
   }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -6,6 +6,11 @@ export interface ActionSpec {
   shadow?: boolean;
 }
 
+export interface SqlActionSpec extends ActionSpec {
+  _: "sql";
+  file: string;
+}
+
 export interface CommandActionSpec extends ActionSpec {
   _: "command";
   command: string;
@@ -32,11 +37,18 @@ export function isActionSpec(o: unknown): o is ActionSpec {
   return true;
 }
 
-export function isCommandActionSpec(o: unknown): o is CommandActionSpec {
-  if (!isActionSpec(o)) {
+export function isSqlActionSpec(o: unknown): o is SqlActionSpec {
+  if (!isActionSpec(o) || o._ !== "sql") {
     return false;
   }
-  if (o._ !== "command") {
+  if (typeof o["file"] !== "string") {
+    throw new Error("SQL command requires 'file' property to be set");
+  }
+  return true;
+}
+
+export function isCommandActionSpec(o: unknown): o is CommandActionSpec {
+  if (!isActionSpec(o) || o._ !== "command") {
     return false;
   }
 


### PR DESCRIPTION
- Actions now have to have a `_` property saying what type of action they are
- Sql action object type added
- String actions are converted to SQL actions at settings parse time
- Extend the 'shadow' setting to work with all command types
- Add some tests

Managed to avoid this without breaking changes; but the old command specs are deprecated and you should update your configs.