### PR TITLE
Document disabling transaction wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,14 +367,19 @@ CREATE OR REPLACE FUNCTION ...;
 DROP FUNCTION IF EXISTS ... CASCADE;
 CREATE OR REPLACE FUNCTION ...
 ```
+## Disable Transaction
+Some migrations require execution outside of a transaction (e.g. to enable augmenting non-DDL-safe things, such as ENUMs in PostgreSQL). To disable wrapping a given migration file in a transaction, use the special comment `--! no-transaction` at the top of the migration file, e.g.
+
+```sql
+--! no-transaction
+ALTER TYPE user_role ADD VALUE 'Admin';
+```
 
 ## TODO:
 
 - [ ] Use a proper CLI parsing library
 
 - [ ] Store pgSettings with committed transactions to protect against user edits
-
-- [ ] Ability to disable transaction in a single migration
 
 - [ ] Add automated tests
 


### PR DESCRIPTION
Currently there is no documentation on disabling the wrapper transaction for migrations, but the feature is implemented. This PR just adds a few lines for those (like me) that need to know how to do that!