### PR TITLE
Add optional names to committed migration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,11 +113,13 @@ If `--shadow` is specified, changes will be applied against the shadow database 
 
 If `--once` is specified, `current.sql` will be ran once and then the command will exit.
 
-### `graphile-migrate commit`
+### `graphile-migrate commit [-m <message>]`
 
 - reset the shadow database to the latest dump
 - apply the current migration to the shadow database, and replace the dump
 - move the current migration to committed migrations (adding a hash to prevent tampering)
+- any whitespace in commit messages will be replaced with `_` and appended to the end of the filename separated by `-`
+- Do **NOT** change the filename or contents once you have committed. If you need to make changes, either add a new migration or, if the migration hasn't been used anywhere else yet, see `uncommit` below.
 
 ### `graphile-migrate uncommit`
 

--- a/src/commands/commit.ts
+++ b/src/commands/commit.ts
@@ -30,8 +30,10 @@ export async function _commit(parsedSettings: ParsedSettings): Promise<void> {
   }
 
   // See if we have a message arg
-  const messageIndex =
-    process.argv.findIndex(arg => arg === "--message" || arg === "-m") + 1;
+  const messageFlagIndex = process.argv.findIndex(
+    arg => arg === "--message" || arg === "-m"
+  );
+  const messageIndex = messageFlagIndex === -1 ? null : messageFlagIndex + 1;
 
   // If we do, fetch, and replace any whitespace with '_'
   const messageFromCommandArgs = messageIndex && process.argv[messageIndex];

--- a/src/migration.ts
+++ b/src/migration.ts
@@ -26,6 +26,7 @@ export interface DbMigration extends Migration {
 
 export interface FileMigration extends Migration {
   body: string;
+  title?: string;
   fullPath: string;
   previous: FileMigration | null;
 }
@@ -78,6 +79,11 @@ export async function _migrateMigrationSchema(
   `);
 }
 
+export const isMigrationFilename = (
+  filename: string
+): RegExpMatchArray | null =>
+  /^[0-9]{6,}(-[-_0-9A-Za-z]+)?\.sql$/.exec(filename);
+
 export async function getLastMigration(
   pgClient: Client,
   parsedSettings: ParsedSettings
@@ -107,12 +113,10 @@ export async function getAllMigrations(
     // noop
   }
   const files = await fsp.readdir(committedMigrationsFolder);
-  const isMigration = (filename: string): RegExpMatchArray | null =>
-    /^[0-9]{6,}\.sql/.exec(filename);
   const migrations: Array<FileMigration> = await Promise.all(
-    files.filter(isMigration).map(
-      async (filename): Promise<FileMigration> => {
-        const fullPath = `${committedMigrationsFolder}/${filename}`;
+    files.filter(isMigrationFilename).map(
+      async (rawFilename): Promise<FileMigration> => {
+        const fullPath = `${committedMigrationsFolder}/${rawFilename}`;
         const contents = await fsp.readFile(fullPath, "utf8");
         const i = contents.indexOf("\n");
         const firstLine = contents.substring(0, i);
@@ -134,8 +138,10 @@ export async function getAllMigrations(
           throw new Error(`Invalid migration header in '${fullPath}'`);
         }
         const body = contents.substring(j + 2);
+        const [filename, title] = rawFilename.replace(".sql", "").split("-");
         return {
-          filename,
+          filename: filename + ".sql",
+          title,
           fullPath,
           hash,
           previousHash,


### PR DESCRIPTION
Completes https://github.com/graphile/migrate/issues/28

## Solution
Adds an optional `-m` flag to the commit command to append a descriptive suffix to migration filenames

## Issues raised in discussion
See original issue for discussion of potential obstacles, and limitations of value. Very salient points raised, and my hope is that this PR addresses them sufficiently.

- **What does it mean for migration uniqueness?**
    - Migrations will still be guaranteed unique. Users choose a (constrained) message to include in their filename, but the original logic for indexing the file prefix remains intact. i.e., filenames will still include an iterated number at the beginning and remain guaranteed unique and ordered even if someone commits two migrations with the same message. 
- **Can migrations be renamed (but persisting the same number) later?**
    - With this PR, they can't. As with the body and original name, these migration suffixes are immutable once they've been accepted. Devs who attempt this should get `error: duplicate key value violates unique constraint "migrations_pkey"` (confirmed by manual test) because they'll be submitting a new file with the same content hash. If they change both the filename and the contents between migrations, they'll end up with `Hash for 000005-<newname>.sql does not match - <hashA> !== <hashB>; has the file been tampered with?` In short, users could mess themselves up by renaming, but no more than they could before. Still, as I'm typing this, I'm realizing that it's probably a good idea to add a starred note this in the readme to mitigate misuse (and I'll do that :D) . 
- ** Do the file names have to be factored into the hash?**
    - They shouldn't need to be, filename is tracked separately for now, and I can't think of any reason to change that (but if anyone else can, I'm definitely interested) They should be immutable, users will get the above errors if they change them manually. 
- **Can we make it so that graphile-migrate uncommit && graphile-migrate commit keeps the same commit message [+] Can we add a comment at the top of current.sql to detail the name that the migration will gain when it is committed?**
    - That's a good idea, but not the way I handled it here. These approaches are certainly not mutually exclusive. The reason I did it like this is because I imagine most dev's workflow involves committing their migration at the same time as their code and possibly long after they last modified current.sql-- command-line just seemed more convenient. Totally open to adding this here or in another PR if anyone feels strongly about it.
- **What is the set of characters that can be included in the filename, how long can it be [...]**
    - I can't think of any reason to restrict this, except that it MUST be consistent with the standards for _detecting_ filename. In this PR, I've abstracted out the `isMigrationFilename` function and used in both places. If it won't be detected on `migrate` it shouldn't be commited on `commit`. The point about non-latin alphabet users made in discussion was a great one-- I'm just going with the validity check that's already there for now.
- **Is this actually useful?**
   - Honestly, it's probably less useful than I thought it was before I read the issue thread, there were some good points there, dumps are a thing ;) 
   - Couple reasons though:
        - Useful in larger teams to be able to quickly find a migration that caused an uncaught problem, to git-blame the file, see what went wrong, etc.
        - Migrations aren't as useful as dumps, but can be useful for a quick peek if you can quickly find where something was added (e.g., "darn, how did I write this pl/pgsql function back when it was working a few migrations ago?"). 
        - As someone who's still learning postgres, I often try to find similar reference migrations to remember how to do something/copy code.
        - Could be useful for quickly associated dump file with a migration in an afterMigration action.
        - Could be useful for associating migrations with the branch they were merged in on.
        - It's present in other migration systems and could help make devs who are adapting this more comfortable (not a great reason, but a reason)

All feedback welcome, not using this wouldn't hurt my feelings-- I completely get why this would be controversial. 
