### PR TITLE
Add option to skip graphile migrate schema create

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ node_modules
 
 # VSCode editor settings
 .vscode
+
+.env
+.gmrc

--- a/README.md
+++ b/README.md
@@ -208,7 +208,8 @@ Configuration goes in `.gmrc`, which is a JSON file with the following keys:
   "Actions" below.
 - `afterCurrent` — optional list of actions to execute after `current.sql` is
   loaded into the database. See "Actions" below.
-- `skipOwnSchema` - optional boolean parameter to skip creation of the `graphile_migrate` schema. 
+- `manageGraphileMigrateSchema` (defaults to `true`) - optional boolean parameter to manage the `graphile_migrate` schema
+  from graphile-migrate or separately. 
   This is useful in environments where the user running the migrations isn't granted schema creation privileges.
 
 What follows is an example configuration file that depends on the following

--- a/README.md
+++ b/README.md
@@ -208,6 +208,8 @@ Configuration goes in `.gmrc`, which is a JSON file with the following keys:
   "Actions" below.
 - `afterCurrent` — optional list of actions to execute after `current.sql` is
   loaded into the database. See "Actions" below.
+- `skipOwnSchema` - optional boolean parameter to skip creation of the `graphile_migrate` schema. 
+  This is useful in environments where the user running the migrations isn't granted schema creation privileges.
 
 What follows is an example configuration file that depends on the following
 environmental variables being set:

--- a/__tests__/__snapshots__/settings.test.ts.snap
+++ b/__tests__/__snapshots__/settings.test.ts.snap
@@ -30,6 +30,7 @@ Object {
   "rootConnectionString": "template1",
   "shadowConnectionString": undefined,
   "shadowDatabaseName": undefined,
+  "skipOwnSchema": false,
 }
 `;
 
@@ -60,6 +61,7 @@ Object {
   "rootConnectionString": "template1",
   "shadowConnectionString": undefined,
   "shadowDatabaseName": undefined,
+  "skipOwnSchema": false,
 }
 `;
 
@@ -85,6 +87,7 @@ Object {
   "rootConnectionString": "template1",
   "shadowConnectionString": undefined,
   "shadowDatabaseName": undefined,
+  "skipOwnSchema": false,
 }
 `;
 
@@ -118,6 +121,7 @@ Object {
   "rootConnectionString": "template1",
   "shadowConnectionString": undefined,
   "shadowDatabaseName": undefined,
+  "skipOwnSchema": false,
 }
 `;
 
@@ -148,5 +152,6 @@ Object {
   "rootConnectionString": "template1",
   "shadowConnectionString": undefined,
   "shadowDatabaseName": undefined,
+  "skipOwnSchema": false,
 }
 `;

--- a/__tests__/__snapshots__/settings.test.ts.snap
+++ b/__tests__/__snapshots__/settings.test.ts.snap
@@ -25,12 +25,12 @@ Object {
   "connectionString": "postgres://localhost:5432/dbname?ssl=1",
   "databaseName": "dbname",
   "databaseOwner": "dbname",
+  "manageGraphileMigrateSchema": true,
   "migrationsFolder": "./migrations",
   "placeholders": undefined,
   "rootConnectionString": "template1",
   "shadowConnectionString": undefined,
   "shadowDatabaseName": undefined,
-  "skipOwnSchema": false,
 }
 `;
 
@@ -56,12 +56,12 @@ Object {
   "connectionString": "postgres://localhost:5432/dbname?ssl=1",
   "databaseName": "dbname",
   "databaseOwner": "dbname",
+  "manageGraphileMigrateSchema": true,
   "migrationsFolder": "./migrations",
   "placeholders": undefined,
   "rootConnectionString": "template1",
   "shadowConnectionString": undefined,
   "shadowDatabaseName": undefined,
-  "skipOwnSchema": false,
 }
 `;
 
@@ -82,12 +82,12 @@ Object {
   "connectionString": "postgres://localhost:5432/dbname?ssl=1",
   "databaseName": "dbname",
   "databaseOwner": "dbname",
+  "manageGraphileMigrateSchema": true,
   "migrationsFolder": "./migrations",
   "placeholders": undefined,
   "rootConnectionString": "template1",
   "shadowConnectionString": undefined,
   "shadowDatabaseName": undefined,
-  "skipOwnSchema": false,
 }
 `;
 
@@ -116,12 +116,12 @@ Object {
   "connectionString": "postgres://localhost:5432/dbname?ssl=1",
   "databaseName": "dbname",
   "databaseOwner": "dbname",
+  "manageGraphileMigrateSchema": true,
   "migrationsFolder": "./migrations",
   "placeholders": undefined,
   "rootConnectionString": "template1",
   "shadowConnectionString": undefined,
   "shadowDatabaseName": undefined,
-  "skipOwnSchema": false,
 }
 `;
 
@@ -147,11 +147,11 @@ Object {
   "connectionString": "postgres://localhost:5432/dbname?ssl=1",
   "databaseName": "dbname",
   "databaseOwner": "dbname",
+  "manageGraphileMigrateSchema": true,
   "migrationsFolder": "./migrations",
   "placeholders": undefined,
   "rootConnectionString": "template1",
   "shadowConnectionString": undefined,
   "shadowDatabaseName": undefined,
-  "skipOwnSchema": false,
 }
 `;

--- a/src/migration.ts
+++ b/src/migration.ts
@@ -82,7 +82,10 @@ export async function getLastMigration(
   pgClient: Client,
   parsedSettings: ParsedSettings
 ): Promise<DbMigration | null> {
-  await _migrateMigrationSchema(pgClient, parsedSettings);
+  if (!parsedSettings.skipOwnSchema) {
+    await _migrateMigrationSchema(pgClient, parsedSettings);
+  }
+
   const {
     rows: [row],
   } = await pgClient.query(

--- a/src/migration.ts
+++ b/src/migration.ts
@@ -82,7 +82,7 @@ export async function getLastMigration(
   pgClient: Client,
   parsedSettings: ParsedSettings
 ): Promise<DbMigration | null> {
-  if (!parsedSettings.skipOwnSchema) {
+  if (parsedSettings.manageGraphileMigrateSchema) {
     await _migrateMigrationSchema(pgClient, parsedSettings);
   }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -59,6 +59,7 @@ export interface Settings {
   shadowConnectionString?: string;
   rootConnectionString?: string;
   databaseOwner?: string;
+  skipOwnSchema?: boolean;
   pgSettings?: {
     [key: string]: string;
   };
@@ -128,7 +129,7 @@ export async function parseSettings(
     ): string => {
       if (typeof rawRootConnectionString !== "string") {
         throw new Error(
-          "Expected a string, or for DATABASE_URL envvar to be set"
+          "Expected a string, or for ROOT_DATABASE_URL envvar to be set"
         );
       }
       return rawRootConnectionString;
@@ -236,6 +237,10 @@ export async function parseSettings(
   const afterAllMigrations = await check("afterAllMigrations", validateAction);
   const afterCurrent = await check("afterCurrent", validateAction);
 
+  const skipOwnSchema = await check("skipOwnSchema", skip => {
+    return !!skip;
+  });
+
   /******/
 
   const uncheckedKeys = keysToCheck.filter(key => !checkedKeys.includes(key));
@@ -280,6 +285,7 @@ export async function parseSettings(
     afterCurrent: afterCurrent!,
     rootConnectionString: rootConnectionString!,
     connectionString: connectionString!,
+    skipOwnSchema: skipOwnSchema!,
     databaseOwner: databaseOwner!,
     migrationsFolder,
     databaseName: databaseName!,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -240,7 +240,7 @@ export async function parseSettings(
   const manageGraphileMigrateSchema = await check(
     "manageGraphileMigrateSchema",
     mgms => {
-      return !mgms;
+      return mgms === undefined || !!mgms;
     }
   );
 
@@ -288,7 +288,7 @@ export async function parseSettings(
     afterCurrent: afterCurrent!,
     rootConnectionString: rootConnectionString!,
     connectionString: connectionString!,
-    manageGraphileMigrateSchema: manageGraphileMigrateSchema!,
+    manageGraphileMigrateSchema: manageGraphileMigrateSchema,
     databaseOwner: databaseOwner!,
     migrationsFolder,
     databaseName: databaseName!,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -59,7 +59,7 @@ export interface Settings {
   shadowConnectionString?: string;
   rootConnectionString?: string;
   databaseOwner?: string;
-  skipOwnSchema?: boolean;
+  manageGraphileMigrateSchema?: boolean;
   pgSettings?: {
     [key: string]: string;
   };
@@ -237,9 +237,12 @@ export async function parseSettings(
   const afterAllMigrations = await check("afterAllMigrations", validateAction);
   const afterCurrent = await check("afterCurrent", validateAction);
 
-  const skipOwnSchema = await check("skipOwnSchema", skip => {
-    return !!skip;
-  });
+  const manageGraphileMigrateSchema = await check(
+    "manageGraphileMigrateSchema",
+    mgms => {
+      return !mgms;
+    }
+  );
 
   /******/
 
@@ -285,7 +288,7 @@ export async function parseSettings(
     afterCurrent: afterCurrent!,
     rootConnectionString: rootConnectionString!,
     connectionString: connectionString!,
-    skipOwnSchema: skipOwnSchema!,
+    manageGraphileMigrateSchema: manageGraphileMigrateSchema!,
     databaseOwner: databaseOwner!,
     migrationsFolder,
     databaseName: databaseName!,


### PR DESCRIPTION
Certain environment don't allow users to create schemas using DDL. 

Adding --skip-own-schema flag allows user to specify that the graphite_migrations schema has already been created (as well as the tables). 