### PR TITLE
feat: use yargs to parse CLI arguments

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -85,5 +85,21 @@ module.exports = {
         "import/no-duplicates": "off",
       },
     },
+    {
+      files: ["scripts/*.js"],
+      parserOptions: {
+        project: null,
+      },
+      rules: {
+        "@typescript-eslint/await-thenable": "off",
+        "@typescript-eslint/explicit-function-return-type": "off",
+        "@typescript-eslint/no-misused-promises": "off",
+        "@typescript-eslint/no-unnecessary-type-assertion": "off",
+        "@typescript-eslint/prefer-includes": "off",
+        "@typescript-eslint/no-var-requires": "off",
+        "@typescript-eslint/prefer-regexp-exec": "off",
+        "@typescript-eslint/prefer-string-starts-ends-with": "off",
+      },
+    },
   ],
 };

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ And please give some love to our featured sponsors 🤩:
 <table><tr>
 <td align="center"><a href="http://chads.website/"><img src="https://www.graphile.org/images/sponsors/chadf.png" width="90" height="90" alt="Chad Furman" /><br />Chad Furman</a></td>
 <td align="center"><a href="https://storyscript.io/?utm_source=postgraphile"><img src="https://www.graphile.org/images/sponsors/storyscript.png" width="90" height="90" alt="Storyscript" /><br />Storyscript</a></td>
-<td align="center"><a href="http://p72.vc/"><img src="https://www.graphile.org/images/sponsors/p72.png" width="90" height="90" alt="Point72 Ventures" /><br />Point72 Ventures</a></td>
 </tr></table>
 
 ## Why?
@@ -38,28 +37,27 @@ And please give some love to our featured sponsors 🤩:
 
 ## Status
 
-**HIGHLY EXPERIMENTAL**
+**EXPERIMENTAL**
 
-If you're a sponsor and you're using this software, let me know so I can justify
-allocating additional time to it.
+Tests are in place for many of the APIs, though the API remains undocumented
+(deliberately) and thus if you use the API directly (as opposed to using the
+CLI) you should expect to have to update your code from time to time. (We advise
+using TypeScript to make spotting breaking changes easier.) There are no
+automated integration tests of the CLI yet (although mostly all it does is hand
+off to the API).
 
-The interface is raw and doesn't ask for confirmation (e.g. the
-`graphile-migrate reset` command will drop and re-create that database without
-asking for confirmation).
+There are people (including the maintainer) using this software to manage
+production databases. It is also used in
+[Graphile Starter](https://github.com/graphile/starter). However, it is not for
+the faint of heart - this software is powerful and requires knowledge of SQL. If
+you don't understand what makes Graphile Migrate awesome, or you're concerned
+about it continuing to evolve, you may want to consider an alternative migration
+framework such as these awesome (and quite diverse) projects:
 
-There are no automated tests yet, and APIs may still change. (Pull requests to
-add tests welcome!)
-
-Using this for prototyping should be fine, but when it comes to shipping you may
-want to
-
-- help us write tests and finalise interfaces
-- send us money to do the same
-- use an alternative migration framework, such as:
-  - [db-migrate](https://db-migrate.readthedocs.io/en/latest/Getting%20Started/commands/)
-  - [sqitch](https://sqitch.org/)
-  - [Flyway](https://flywaydb.org/)
-  - [migra](https://github.com/djrobstep/migra)
+- [db-migrate](https://db-migrate.readthedocs.io/en/latest/Getting%20Started/commands/)
+- [sqitch](https://sqitch.org/)
+- [Flyway](https://flywaydb.org/)
+- [migra](https://github.com/djrobstep/migra)
 
 ## Opinions
 
@@ -91,7 +89,7 @@ want to
 
 ## Setup
 
-`graphile-migrations` requires two databases: the first is your main database
+`graphile-migrate` requires two databases: the first is your main database
 against which you perform development, the second is a "shadow" database which
 is used by the system to apply migrations. You should never interact with the
 "shadow" database directly. Further all members of your team should run the same

--- a/README.md
+++ b/README.md
@@ -146,13 +146,15 @@ Will only work when `current.sql` is empty(ish).
 Do **NOT** use it once other systems have ran the commit. This is for use during
 development only, probably before your changes are pushed/merged.
 
-### `graphile-migrate reset [--shadow]`
+### `graphile-migrate reset [--shadow] [--erase]`
 
 Drop and re-create the database, and re-run all the committed migrations from
 the start. **HIGHLY DESTRUCTIVE**
 
 If `--shadow` is specified, the shadow database will be reset rather than the
 main database.
+
+`--erase` is required after v0.1.0 to help avoid accidental invocation.
 
 ### `graphile-migrate status`
 

--- a/README.md
+++ b/README.md
@@ -532,11 +532,7 @@ PR to this paragraph.)
 
 ## TODO:
 
-- [ ] Use a proper CLI parsing library
-
 - [ ] Store pgSettings with committed transactions to protect against user edits
-
-- [ ] Add automated tests
 
 - [ ] Add `graphile-migrate check` command: reset the shadow database to the
       latest dump, apply the current migration to the shadow database, and

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -77,7 +77,9 @@ async function createDatabases() {
       [TEST_DATABASE_NAME, TEST_SHADOW_DATABASE_NAME, user],
     );
     if (!result) {
+      // eslint-disable-next-line no-console
       console.dir(client.query);
+      // eslint-disable-next-line no-console
       console.dir(result);
       throw new Error("No result?!");
     }

--- a/package.json
+++ b/package.json
@@ -39,12 +39,14 @@
   "homepage": "https://github.com/graphile/migrate#readme",
   "dependencies": {
     "@types/pg": "^7.14.1",
+    "@types/yargs": "^15.0.4",
     "chalk": "^3.0.0",
     "chokidar": "^3.3.1",
     "pg": ">=6.5 <8",
     "pg-connection-string": "^2.1.0",
     "pg-minify": "^1.5.2",
-    "tslib": "^1.10.0"
+    "tslib": "^1.10.0",
+    "yargs": "^15.3.1"
   },
   "devDependencies": {
     "@types/jest": "^25.1.2",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   "homepage": "https://github.com/graphile/migrate#readme",
   "dependencies": {
     "@types/pg": "^7.14.1",
-    "@types/yargs": "^15.0.4",
     "chalk": "^3.0.0",
     "chokidar": "^3.3.1",
     "pg": ">=6.5 <8",
@@ -51,6 +50,7 @@
   "devDependencies": {
     "@types/jest": "^25.1.2",
     "@types/mock-fs": "^4.10.0",
+    "@types/yargs": "^15.0.4",
     "@typescript-eslint/eslint-plugin": "^2.19.0",
     "@typescript-eslint/parser": "^2.19.0",
     "depcheck": "^0.9.2",

--- a/scripts/update-docs.js
+++ b/scripts/update-docs.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+const { promises: fsp } = require("fs");
+const { spawnSync } = require("child_process");
+
+async function main() {
+  const readmePath = `${__dirname}/../README.md`;
+  const readme = await fsp.readFile(readmePath, "utf8");
+  const { stdout: usage } = await spawnSync("bash", [`${__dirname}/usage`], {
+    encoding: "utf8",
+  });
+  await fsp.writeFile(
+    readmePath,
+    readme.replace(
+      /(<!-- CLI_USAGE_BEGIN -->)[\s\S]*(<!-- CLI_USAGE_END -->)/,
+      (_, start, fin) => `${start}\n${usage.trim()}\n${fin}`,
+    ),
+  );
+}
+
+main().catch(e => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/update-docs.js
+++ b/scripts/update-docs.js
@@ -18,6 +18,7 @@ async function main() {
 }
 
 main().catch(e => {
+  // eslint-disable-next-line no-console
   console.error(e);
   process.exit(1);
 });

--- a/scripts/usage
+++ b/scripts/usage
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+cd "$(dirname "$0")"
+export GRAPHILE_SPONSOR=1
+
+GRAPHILE_MIGRATE="node ../dist/cli.js"
+
+echo -e '## graphile-migrate\n\n```'
+$GRAPHILE_MIGRATE --help
+echo -e '```\n\n'
+
+echo -e '## graphile-migrate migrate\n\n```'
+$GRAPHILE_MIGRATE migrate --help
+echo -e '```\n\n'
+
+echo -e '## graphile-migrate watch\n\n```'
+$GRAPHILE_MIGRATE watch --help
+echo -e '```\n\n'
+
+echo -e '## graphile-migrate commit\n\n```'
+$GRAPHILE_MIGRATE commit --help
+echo -e '```\n\n'
+
+echo -e '## graphile-migrate uncommit\n\n```'
+$GRAPHILE_MIGRATE uncommit --help
+echo -e '```\n\n'
+
+echo -e '## graphile-migrate reset\n\n```'
+$GRAPHILE_MIGRATE reset --help
+echo -e '```\n\n'
+
+echo -e '## graphile-migrate status\n\n```'
+$GRAPHILE_MIGRATE status --help
+echo -e '```\n\n'

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -60,7 +60,6 @@ yargs
   .strict(true)
   .version(version)
   .help(true)
-  .completion("completion", "Generate shell completion script.")
   .demandCommand(1, 1, "Please select a command to run.")
   .recommendCommands()
 
@@ -72,12 +71,18 @@ yargs
   .command(wrapHandler(statusCommand))
   .command(wrapHandler(resetCommand))
 
+  .completion("completion", "Generate shell completion script.")
   .epilogue(
     `\
 You are running graphile-migrate v${version}.
 
-Please consider supporting Graphile Migrate development: 
-
-  https://www.graphile.org/sponsor/
+  ╔═══════════════════════════════════╗
+  ║ Graphile Migrate is crowd-funded, ║
+  ║   please consider sponsorship:    ║
+  ║                                   ║
+  ║ https://www.graphile.org/sponsor/ ║
+  ║                                   ║
+  ║     🙏 THANK YOU SPONSORS! 🙏     ║
+  ╚═══════════════════════════════════╝
 `,
   ).argv;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,7 @@ import { version } from "../package.json";
 import { commitCommand } from "./commands/commit";
 import { migrateCommand } from "./commands/migrate";
 import { resetCommand } from "./commands/reset";
+import { uncommitCommand } from "./commands/uncommit";
 import { watchCommand } from "./commands/watch";
 
 yargs
@@ -39,6 +40,7 @@ yargs
   .command(migrateCommand)
   .command(watchCommand)
   .command(commitCommand)
+  .command(uncommitCommand)
   .command(resetCommand)
 
   .epilogue(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,8 +4,9 @@ import * as yargs from "yargs";
 // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 // @ts-ignore
 import { version } from "../package.json";
+import { commitCommand } from "./commands/commit";
 import { migrateCommand } from "./commands/migrate";
-import { resetCommand } from "./commands/reset.js";
+import { resetCommand } from "./commands/reset";
 import { watchCommand } from "./commands/watch";
 
 yargs
@@ -37,6 +38,7 @@ yargs
   // Commands
   .command(migrateCommand)
   .command(watchCommand)
+  .command(commitCommand)
   .command(resetCommand)
 
   .epilogue(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@ import * as yargs from "yargs";
 // @ts-ignore
 import { version } from "../package.json";
 import { migrateCommand } from "./commands/migrate";
+import { resetCommand } from "./commands/reset.js";
 import { watchCommand } from "./commands/watch";
 
 yargs
@@ -36,6 +37,7 @@ yargs
   // Commands
   .command(migrateCommand)
   .command(watchCommand)
+  .command(resetCommand)
 
   .epilogue(
     `\

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@ import * as yargs from "yargs";
 // @ts-ignore
 import { version } from "../package.json";
 import { migrateCommand } from "./commands/migrate";
+import { watchCommand } from "./commands/watch";
 
 yargs
   .parserConfiguration({
@@ -34,6 +35,7 @@ yargs
 
   // Commands
   .command(migrateCommand)
+  .command(watchCommand)
 
   .epilogue(
     `\

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -59,6 +59,7 @@ yargs
 
   .strict(true)
   .version(version)
+  .hide("version")
   .help(true)
   .demandCommand(1, 1, "Please select a command to run.")
   .recommendCommands()
@@ -73,7 +74,10 @@ yargs
 
   .completion("completion", "Generate shell completion script.")
   .epilogue(
-    `\
+    process.env.GRAPHILE_SPONSOR
+      ? `\
+You are running graphile-migrate v${version}.`
+      : `\
 You are running graphile-migrate v${version}.
 
   ╔═══════════════════════════════════╗

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,7 @@ import { version } from "../package.json";
 import { commitCommand } from "./commands/commit";
 import { migrateCommand } from "./commands/migrate";
 import { resetCommand } from "./commands/reset";
+import { statusCommand } from "./commands/status";
 import { uncommitCommand } from "./commands/uncommit";
 import { watchCommand } from "./commands/watch";
 
@@ -41,6 +42,7 @@ yargs
   .command(watchCommand)
   .command(commitCommand)
   .command(uncommitCommand)
+  .command(statusCommand)
   .command(resetCommand)
 
   .epilogue(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -61,6 +61,7 @@ yargs
   .version(version)
   .help(true)
   .completion("completion", "Generate shell completion script.")
+  .demandCommand(1, 1, "Please select a command to run.")
   .recommendCommands()
 
   // Commands
@@ -79,5 +80,4 @@ Please consider supporting Graphile Migrate development:
 
   https://www.graphile.org/sponsor/
 `,
-  )
-  .demandCommand(1, 1, "Please select a command to run.").argv;
+  ).argv;

--- a/src/commands/_common.ts
+++ b/src/commands/_common.ts
@@ -1,0 +1,19 @@
+import { promises as fsp } from "fs";
+
+import { Settings } from "../settings";
+
+export async function getSettings(): Promise<Settings> {
+  let data;
+  try {
+    data = await fsp.readFile(`${process.cwd()}/.gmrc`, "utf8");
+  } catch (e) {
+    throw new Error(
+      "No .gmrc file found; please run `graphile-migrate init` first.",
+    );
+  }
+  try {
+    return JSON.parse(data);
+  } catch (e) {
+    throw new Error("Failed to parse .gmrc file: " + e.message);
+  }
+}

--- a/src/commands/commit.ts
+++ b/src/commands/commit.ts
@@ -146,6 +146,9 @@ export const commitCommand: CommandModule<
     },
   },
   handler: async argv => {
+    if (argv.message !== undefined && !argv.message) {
+      throw new Error("Missing or empty commit message after --message flag");
+    }
     await commit(await getSettings(), argv.message);
   },
 };

--- a/src/commands/commit.ts
+++ b/src/commands/commit.ts
@@ -139,6 +139,7 @@ export const commitCommand: CommandModule<
   builder: {
     message: {
       type: "string",
+      alias: ["m"],
       description:
         "Optional commit message to label migration, must not contain newlines.",
       nargs: 1,

--- a/src/commands/commit.ts
+++ b/src/commands/commit.ts
@@ -141,6 +141,7 @@ export const commitCommand: CommandModule<
       type: "string",
       description:
         "Optional commit message to label migration, must not contain newlines.",
+      nargs: 1,
     },
   },
   handler: async argv => {

--- a/src/commands/commit.ts
+++ b/src/commands/commit.ts
@@ -1,5 +1,6 @@
 import pgMinify = require("pg-minify");
 import { promises as fsp } from "fs";
+import { CommandModule } from "yargs";
 
 import {
   getCurrentMigrationLocation,
@@ -16,6 +17,7 @@ import {
 } from "../migration";
 import { ParsedSettings, parseSettings, Settings } from "../settings";
 import { sluggify } from "../sluggify";
+import { getSettings } from "./_common";
 import { _migrate } from "./migrate";
 import { _reset } from "./reset";
 
@@ -123,3 +125,25 @@ export async function commit(
   const parsedSettings = await parseSettings(settings, true);
   return _commit(parsedSettings, message);
 }
+
+export const commitCommand: CommandModule<
+  never,
+  {
+    message?: string;
+  }
+> = {
+  command: "commit",
+  aliases: [],
+  describe:
+    "Commits the current migration into the `committed/` folder, resetting the current migration file(s).",
+  builder: {
+    message: {
+      type: "string",
+      description:
+        "Optional commit message to label migration, must not contain newlines.",
+    },
+  },
+  handler: async argv => {
+    await commit(await getSettings(), argv.message);
+  },
+};

--- a/src/commands/commit.ts
+++ b/src/commands/commit.ts
@@ -135,7 +135,7 @@ export const commitCommand: CommandModule<
   command: "commit",
   aliases: [],
   describe:
-    "Commits the current migration into the `committed/` folder, resetting the current migration file(s).",
+    "Commits the current migration into the `committed/` folder, resetting the current migration. Resets the shadow database.",
   builder: {
     message: {
       type: "string",

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -1,3 +1,5 @@
+import { CommandBuilder, CommandModule } from "yargs";
+
 import { executeActions } from "../actions";
 import {
   getLastMigration,
@@ -6,6 +8,7 @@ import {
 } from "../migration";
 import { withClient } from "../pg";
 import { ParsedSettings, parseSettings, Settings } from "../settings";
+import { getSettings } from "./_common";
 
 export async function _migrate(
   parsedSettings: ParsedSettings,
@@ -67,3 +70,29 @@ export async function migrate(
   const parsedSettings = await parseSettings(settings, shadow);
   return _migrate(parsedSettings, shadow, force);
 }
+
+export const migrateCommand: CommandModule<
+  never,
+  {
+    shadow: boolean;
+    force: boolean;
+  }
+> = {
+  command: "migrate",
+  aliases: [],
+  describe:
+    "Runs any un-executed committed migrations. Does NOT run `current.sql`. For use in production and development.",
+  builder: {
+    shadow: {
+      type: "boolean",
+      default: false,
+    },
+    force: {
+      type: "boolean",
+      default: false,
+    },
+  },
+  handler: async argv => {
+    await migrate(await getSettings(), argv.shadow, argv.force);
+  },
+};

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -81,7 +81,7 @@ export const migrateCommand: CommandModule<
   command: "migrate",
   aliases: [],
   describe:
-    "Runs any un-executed committed migrations. Does NOT run `current.sql`. For use in production and development.",
+    "Runs any un-executed committed migrations. Does NOT run the current migration. For use in production and development.",
   builder: {
     shadow: {
       type: "boolean",

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -1,4 +1,4 @@
-import { CommandBuilder, CommandModule } from "yargs";
+import { CommandModule } from "yargs";
 
 import { executeActions } from "../actions";
 import {

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -86,10 +86,13 @@ export const migrateCommand: CommandModule<
     shadow: {
       type: "boolean",
       default: false,
+      description: "Apply migrations to the shadow DB (for development).",
     },
     force: {
       type: "boolean",
       default: false,
+      description:
+        "Run afterAllMigrations actions even if no migration was necessary.",
     },
   },
   handler: async argv => {

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -45,7 +45,7 @@ export const statusCommand: CommandModule<never, {}> = {
   describe:
     "Exits with a bitmap status code indicating statuses (1 = unexecuted committed migrations, 2 = current migration is non-empty)",
   builder: {},
-  handler: async argv => {
+  handler: async () => {
     /* eslint-disable no-console */
     let exitCode = 0;
     const details = await status(await getSettings());

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -63,7 +63,7 @@ export const statusCommand: CommandModule<never, {}> = {
         console.log();
       }
       console.log(
-        "The current.sql migration is not empty and has not been committed.",
+        "The current migration is not empty and has not been committed.",
       );
       exitCode += 2;
     }

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,8 +1,11 @@
 import pgMinify = require("pg-minify");
+import { CommandModule } from "yargs";
+
 import { getCurrentMigrationLocation, readCurrentMigration } from "../current";
 import { getLastMigration, getMigrationsAfter } from "../migration";
 import { withClient } from "../pg";
 import { ParsedSettings, parseSettings, Settings } from "../settings";
+import { getSettings } from "./_common";
 
 interface Status {
   remainingMigrations: Array<string>;
@@ -35,3 +38,43 @@ export async function status(settings: Settings): Promise<Status> {
   const parsedSettings = await parseSettings(settings, true);
   return _status(parsedSettings);
 }
+
+export const statusCommand: CommandModule<never, {}> = {
+  command: "status",
+  aliases: [],
+  describe:
+    "Exits with a bitmap status code indicating statuses (1 = unexecuted committed migrations, 2 = current migration is non-empty)",
+  builder: {},
+  handler: async argv => {
+    /* eslint-disable no-console */
+    let exitCode = 0;
+    const details = await status(await getSettings());
+    const remainingCount = details.remainingMigrations.length;
+    if (remainingCount) {
+      console.log(
+        `There are ${remainingCount} committed migrations pending:\n\n  ${details.remainingMigrations.join(
+          "\n  ",
+        )}`,
+      );
+      exitCode += 1;
+    }
+    if (details.hasCurrentMigration) {
+      if (exitCode) {
+        console.log();
+      }
+      console.log(
+        "The current.sql migration is not empty and has not been committed.",
+      );
+      exitCode += 2;
+    }
+
+    // ESLint false positive.
+    // eslint-disable-next-line require-atomic-updates
+    process.exitCode = exitCode;
+
+    if (exitCode === 0) {
+      console.log("Up to date.");
+    }
+    /* eslint-enable */
+  },
+};

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -42,8 +42,14 @@ export async function status(settings: Settings): Promise<Status> {
 export const statusCommand: CommandModule<never, {}> = {
   command: "status",
   aliases: [],
-  describe:
-    "Exits with a bitmap status code indicating statuses (1 = unexecuted committed migrations, 2 = current migration is non-empty)",
+  describe: `\
+Exits with a bitmap status code indicating statuses:
+
+- 1 if there are committed migrations that have not been executed yet
+- 2 if the current migration is non-empty (ignoring comments)
+
+If both of the above are true then the output status will be 3 (1+2). If neither
+are true, exit status will be 0 (success). Additional messages may also be output.`,
   builder: {},
   handler: async () => {
     /* eslint-disable no-console */

--- a/src/commands/uncommit.ts
+++ b/src/commands/uncommit.ts
@@ -68,7 +68,7 @@ export const uncommitCommand: CommandModule<never, {}> = {
   command: "uncommit",
   aliases: [],
   describe:
-    "Undoes the latest `commit`. Development only, and liable to cause conflicts with other developers. Be careful.",
+    "Moves the latest commit out of the committed migrations folder and back to the current migration (assuming the current migration is empty-ish). Removes the migration tracking entry from ONLY the local database, do not use after other databases have executed this committed migration. Development only, and liable to cause conflicts with other developers. Be careful.",
   builder: {},
   handler: async argv => {
     if (argv.message !== undefined && !argv.message) {

--- a/src/commands/uncommit.ts
+++ b/src/commands/uncommit.ts
@@ -1,5 +1,6 @@
 import pgMinify = require("pg-minify");
 import { promises as fsp } from "fs";
+import { CommandModule } from "yargs";
 
 import {
   getCurrentMigrationLocation,
@@ -13,6 +14,7 @@ import {
   undoMigration,
 } from "../migration";
 import { ParsedSettings, parseSettings, Settings } from "../settings";
+import { getSettings } from "./_common";
 import { _migrate } from "./migrate";
 import { _reset } from "./reset";
 
@@ -61,3 +63,17 @@ export async function uncommit(settings: Settings): Promise<void> {
   const parsedSettings = await parseSettings(settings, true);
   return _uncommit(parsedSettings);
 }
+
+export const uncommitCommand: CommandModule<never, {}> = {
+  command: "uncommit",
+  aliases: [],
+  describe:
+    "Undoes the latest `commit`. Development only, and liable to cause conflicts with other developers. Be careful.",
+  builder: {},
+  handler: async argv => {
+    if (argv.message !== undefined && !argv.message) {
+      throw new Error("Missing or empty commit message after --message flag");
+    }
+    await uncommit(await getSettings());
+  },
+};

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -7,11 +7,14 @@ import { withClient, withTransaction } from "../pg";
 import { ParsedSettings, parseSettings, Settings } from "../settings";
 import { _migrate } from "./migrate";
 import pgMinify = require("pg-minify");
+import { CommandModule } from "yargs";
+
 import {
   getCurrentMigrationLocation,
   readCurrentMigration,
   writeCurrentMigration,
 } from "../current";
+import { getSettings } from "./_common";
 
 export function _makeCurrentMigrationRunner(
   parsedSettings: ParsedSettings,
@@ -223,3 +226,31 @@ export async function watch(
   const parsedSettings = await parseSettings(settings, shadow);
   return _watch(parsedSettings, once, shadow);
 }
+
+export const watchCommand: CommandModule<
+  never,
+  {
+    once: boolean;
+    shadow: boolean;
+  }
+> = {
+  command: "watch",
+  aliases: [],
+  describe:
+    "Runs any un-executed committed migrations and then runs and watches `current.sql`, re-running its contents on any change. For development.",
+  builder: {
+    once: {
+      type: "boolean",
+      default: false,
+      description: "Runs `current.sql` and then exits.",
+    },
+    shadow: {
+      type: "boolean",
+      default: false,
+      description: "Applies migrations to shadow DB.",
+    },
+  },
+  handler: async argv => {
+    await watch(await getSettings(), argv.once, argv.shadow);
+  },
+};

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -237,17 +237,17 @@ export const watchCommand: CommandModule<
   command: "watch",
   aliases: [],
   describe:
-    "Runs any un-executed committed migrations and then runs and watches `current.sql`, re-running its contents on any change. For development.",
+    "Runs any un-executed committed migrations and then runs and watches the current migration, re-running it on any change. For development.",
   builder: {
     once: {
       type: "boolean",
       default: false,
-      description: "Runs `current.sql` and then exits.",
+      description: "Runs the current migration and then exits.",
     },
     shadow: {
       type: "boolean",
       default: false,
-      description: "Applies migrations to shadow DB.",
+      description: "Applies changes to shadow DB.",
     },
   },
   handler: async argv => {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -55,6 +55,10 @@ export function isCommandActionSpec(o: unknown): o is CommandActionSpec {
   return true;
 }
 
+/**
+ * This type is not trusted; to use the values within it, it must be
+ * parsed/validated into ParsedSettings.
+ */
 export interface Settings {
   connectionString?: string;
   shadowConnectionString?: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -455,6 +455,13 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@types/yargs@^15.0.4":
+  version "15.0.4"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.4.tgz#7e5d0f8ca25e9d5849f2ea443cf7c402decd8299"
+  integrity sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==
+  dependencies:
+    "@types/yargs-parser" "*"
+
 "@typescript-eslint/eslint-plugin@^2.19.0":
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.19.0.tgz#bf743448a4633e4b52bee0c40148ba072ab3adbd"
@@ -4472,6 +4479,14 @@ yargs-parser@^16.1.0:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
+yargs-parser@^18.1.1:
+  version "18.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.1.tgz#bf7407b915427fc760fcbbccc6c82b4f0ffcbd37"
+  integrity sha512-KRHEsOM16IX7XuLnMOqImcPNbLVXMNHYAoFc3BKR8Ortl5gzDbtXvvEoGx9imk5E+X1VeNKNlcHr8B8vi+7ipA==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
 yargs@^15.0.0, yargs@^15.0.2:
   version "15.1.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.1.0.tgz#e111381f5830e863a89550bd4b136bb6a5f37219"
@@ -4488,3 +4503,20 @@ yargs@^15.0.0, yargs@^15.0.2:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^16.1.0"
+
+yargs@^15.3.1:
+  version "15.3.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.3.1.tgz#9505b472763963e54afe60148ad27a330818e98b"
+  integrity sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==
+  dependencies:
+    cliui "^6.0.0"
+    decamelize "^1.2.0"
+    find-up "^4.1.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^4.2.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^18.1.1"


### PR DESCRIPTION
Correctly handles missing arguments, comes with help text, sensible defaults, better code structure, etc.

Fixes #54 
```
graphile-migrate <command>

Commands:
  graphile-migrate migrate     Runs any un-executed committed migrations. Does
                               NOT run the current migration. For use in
                               production and development.
  graphile-migrate watch       Runs any un-executed committed migrations and
                               then runs and watches the current migration,
                               re-running it on any change. For development.
  graphile-migrate commit      Commits the current migration into the
                               `committed/` folder, resetting the current
                               migration. Resets the shadow database.
  graphile-migrate uncommit    Moves the latest commit out of the committed
                               migrations folder and back to the current
                               migration (assuming the current migration is
                               empty-ish). Removes the migration tracking entry
                               from ONLY the local database, do not use after
                               other databases have executed this committed
                               migration. Development only, and liable to cause
                               conflicts with other developers. Be careful.
  graphile-migrate status      Exits with a bitmap status code indicating
                               statuses:

                               - 1 if there are committed migrations that have
                               not been executed yet
                               - 2 if the current migration is non-empty
                               (ignoring comments)

                               If both of the above are true then the output
                               status will be 3 (1+2). If neither
                               are true, exit status will be 0 (success).
                               Additional messages may also be output.
  graphile-migrate reset       Drops and re-creates the database, re-running all
                               committed migrations from the start. **HIGHLY
                               DESTRUCTIVE**.
  graphile-migrate completion  Generate shell completion script.

Options:
  --help  Show help                                                    [boolean]

You are running graphile-migrate v0.0.18.
```