### PR TITLE
fix: use realFilename in logs/errors

### DIFF
--- a/src/migration.ts
+++ b/src/migration.ts
@@ -454,16 +454,24 @@ export async function runCommittedMigration(
   committedMigration: FileMigration,
   logSuffix: string,
 ): Promise<void> {
-  const { hash, filename, body, previousHash } = committedMigration;
+  const {
+    hash,
+    realFilename,
+    filename,
+    body,
+    previousHash,
+  } = committedMigration;
   // Check the hash
   const newHash = calculateHash(body, previousHash);
   if (newHash !== hash) {
     throw new Error(
-      `Hash for ${filename} does not match - ${newHash} !== ${hash}; has the file been tampered with?`,
+      `Hash for ${realFilename} does not match - ${newHash} !== ${hash}; has the file been tampered with?`,
     );
   }
   // eslint-disable-next-line no-console
-  console.log(`graphile-migrate${logSuffix}: Running migration '${filename}'`);
+  console.log(
+    `graphile-migrate${logSuffix}: Running migration '${realFilename}'`,
+  );
   await runStringMigration(
     pgClient,
     parsedSettings,


### PR DESCRIPTION
Previously filename without message was used in "Running migration" log and in "Hash for 'filename' does not match". Now actual filesystem filename is used. Migrations table still stores filename without message.