### PR TITLE
feat: ensure connection strings are distinct

### DIFF
--- a/__tests__/settings.test.ts
+++ b/__tests__/settings.test.ts
@@ -29,6 +29,38 @@ it("throws error for missing connection string", async () => {
         `);
 });
 
+it("throws error if connection string is the same as root connection string", async () => {
+  await expect(
+    parseSettings(
+      {
+        connectionString: exampleConnectionString,
+        rootConnectionString: exampleConnectionString,
+        shadowConnectionString: "notthesamestring",
+      },
+      true,
+    ),
+  ).rejects.toMatchInlineSnapshot(`
+          [Error: Errors occurred during settings validation:
+          - connectionString cannot be the same value as rootConnectionString or shadowConnectionString.]
+    `);
+});
+
+it("throws error if connection string is the same as shadow connection string", async () => {
+  await expect(
+    parseSettings(
+      {
+        connectionString: exampleConnectionString,
+        rootConnectionString: "notthesamestring",
+        shadowConnectionString: exampleConnectionString,
+      },
+      true,
+    ),
+  ).rejects.toMatchInlineSnapshot(`
+          [Error: Errors occurred during settings validation:
+          - connectionString cannot be the same value as rootConnectionString or shadowConnectionString.]
+    `);
+});
+
 it("throws if shadow attempted but no shadow DB", async () => {
   await expect(
     parseSettings(

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -325,6 +325,15 @@ export async function parseSettings(
         "Could not determine the database name, please ensure connectionString includes the database name.",
       );
     }
+
+    if (
+      connectionString === rootConnectionString ||
+      (requireShadow && connectionString === shadowConnectionString)
+    ) {
+      errors.push(
+        "connectionString cannot be the same value as rootConnectionString or shadowConnectionString.",
+      );
+    }
   }
 
   if (requireShadow && !shadowDatabaseName) {


### PR DESCRIPTION
As discussed in Discord, this:
- [x] checks `connectionString !== shadowConnectionString`
- [x] checks `connectionString !== rootConnectionString`
- [x] adds some simple instructions for getting the tests to pass in a container

I thought it was probably safe to leave `rootConnectionString !== shadowConnectionString` up to the user's brain :slightly_smiling_face: 