### PR TITLE
Fix small grammar issue in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,10 @@ And please give some love to our featured sponsors 🤩:
 
 ## Setup
 
-In development `graphile-migrate` requires two databases: the
-first is your main development database, the second is a "shadow" database which
-is used by the system to test migrations are consistent. You should never
-interact with the "shadow" database directly. In production you'll only have the
-main database.
+In development `graphile-migrate` requires two databases: the first is your main
+development database, the second is a "shadow" database which is used by the
+system to test migrations are consistent. You should never interact with the
+"shadow" database directly. In production you'll only have the main database.
 
 All members of your team should run the same PostgreSQL version to ensure that
 the shadow dump matches for everyone (one way of achieving this is through

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ And please give some love to our featured sponsors 🤩:
 
 ## Setup
 
-In development, `graphile-migrate` requires two databases in development: the
+In development `graphile-migrate` requires two databases: the
 first is your main development database, the second is a "shadow" database which
 is used by the system to test migrations are consistent. You should never
 interact with the "shadow" database directly. In production you'll only have the


### PR DESCRIPTION

## Description
Removed redundant "in development" in first sentence of Setup section.

## Performance impact
None

## Security impact
None

## Checklist


- [n/a] My code matches the project's code style and `yarn lint:fix` passes.
- [n/a] I've added tests for the new feature, and `yarn test` passes.
- [n/a] I have detailed the new feature in the relevant documentation.
- [n/a] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [n/a] If this is a breaking change I've explained why.
