### PR TITLE
docs(README): clarify shadow database isn't needed in production

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,14 @@ And please give some love to our featured sponsors 🤩:
 
 ## Setup
 
-`graphile-migrate` uses two databases in development mode. A development database and 
-a "shadow" database. The "shadow" database is used by `graphile-migrate` to test the 
-consistency of the migrations. Only a single database is used in production environments.
+In development, `graphile-migrate` uses two databases: the main database and a
+"shadow" database. The "shadow" database is used internally by
+`graphile-migrate` to test the consistency of the migrations and perform various
+other tasks.
+
+In production, you'll likely only need to run `graphile-migrate migrate` which
+only requires the main database - there is no need for a shadow database in
+production.
 
 All members of your team should run the same PostgreSQL version to ensure that
 the shadow dump matches for everyone (one way of achieving this is through

--- a/README.md
+++ b/README.md
@@ -72,10 +72,9 @@ And please give some love to our featured sponsors 🤩:
 
 ## Setup
 
-In development `graphile-migrate` requires two databases: the first is your main
-development database, the second is a "shadow" database which is used by the
-system to test migrations are consistent. You should never interact with the
-"shadow" database directly. In production you'll only have the main database.
+`graphile-migrate` uses two databases in development mode. A development database and 
+a "shadow" database. The "shadow" database is used by `graphile-migrate` to test the 
+consistency of the migrations. Only a single database is used in production environments.
 
 All members of your team should run the same PostgreSQL version to ensure that
 the shadow dump matches for everyone (one way of achieving this is through


### PR DESCRIPTION
## Description

There's still confusion over whether the shadow database is needed in production or not; this PR aims to address this by being more explicit.

## Performance impact

None.

## Security impact

None.

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [ ] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
