### PR TITLE
feat: add --config option for custom .grmc(.js) path

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,8 +223,8 @@ Commands:
   graphile-migrate completion      Generate shell completion script.
 
 Options:
-  --help  Show help                                                    [boolean]
-  --config Optional path to .gmrc(.js) - default is `${pwd}.gmrc`      [string]
+  --help        Show help                                              [boolean]
+  --config, -c  Optional path to .gmrc(.js) - default is `${pwd}.gmrc`  [string]
 
 You are running graphile-migrate v1.0.2.
 ```
@@ -239,9 +239,9 @@ Initializes a graphile-migrate project by creating a `.gmrc` file and
 `migrations` folder.
 
 Options:
-  --help    Show help                                                  [boolean]
-  --config Optional path to .gmrc(.js) - default is `${pwd}.gmrc`      [string]
-  --folder  Use a folder rather than a file for the current migration.
+  --help        Show help                                              [boolean]
+  --config, -c  Optional path to .gmrc(.js) - default is `${pwd}.gmrc`  [string]
+  --folder      Use a folder rather than a file for the current migration.
                                                       [boolean] [default: false]
 ```
 
@@ -256,7 +256,7 @@ For use in production and development.
 
 Options:
   --help          Show help                                            [boolean]
-  --config Optional path to .gmrc(.js) - default is `${pwd}.gmrc`      [string]
+  --config, -c    Optional path to .gmrc(.js) - default is `${pwd}.gmrc`[string]
   --shadow        Apply migrations to the shadow DB (for development).
                                                       [boolean] [default: false]
   --forceActions  Run beforeAllMigrations and afterAllMigrations actions even if
@@ -273,10 +273,11 @@ Runs any un-executed committed migrations and then runs and watches the current
 migration, re-running it on any change. For development.
 
 Options:
-  --help    Show help                                                  [boolean]
-  --config Optional path to .gmrc(.js) - default is `${pwd}.gmrc`      [string]
-  --once    Runs the current migration and then exits.[boolean] [default: false]
-  --shadow  Applies changes to shadow DB.             [boolean] [default: false]
+  --help        Show help                                              [boolean]
+  --config, -c  Optional path to .gmrc(.js) - default is `${pwd}.gmrc`  [string]
+  --once        Runs the current migration and then exits.
+                                                      [boolean] [default: false]
+  --shadow      Applies changes to shadow DB.         [boolean] [default: false]
 ```
 
 
@@ -290,7 +291,7 @@ current migration. Resets the shadow database.
 
 Options:
   --help         Show help                                             [boolean]
-  --config Optional path to .gmrc(.js) - default is `${pwd}.gmrc`      [string]
+  --config, -c   Optional path to .gmrc(.js) - default is `${pwd}.gmrc` [string]
   --message, -m  Optional commit message to label migration, must not contain
                  newlines.                                              [string]
 ```
@@ -313,8 +314,8 @@ should result in the exact same hash. Development only, and liable to cause
 conflicts with other developers - be careful.
 
 Options:
-  --help  Show help                                                    [boolean]
-  --config Optional path to .gmrc(.js) - default is `${pwd}.gmrc`      [string]
+  --help        Show help                                              [boolean]
+  --config, -c  Optional path to .gmrc(.js) - default is `${pwd}.gmrc`  [string]
 ```
 
 
@@ -327,11 +328,11 @@ Drops and re-creates the database, re-running all committed migrations from the
 start. **HIGHLY DESTRUCTIVE**.
 
 Options:
-  --help    Show help                                                  [boolean]
-  --config Optional path to .gmrc(.js) - default is `${pwd}.gmrc`      [string]
-  --shadow  Applies migrations to shadow DB.          [boolean] [default: false]
-  --erase   This is your double opt-in to make it clear this DELETES EVERYTHING.
-                                                      [boolean] [default: false]
+  --help        Show help                                              [boolean]
+  --config, -c  Optional path to .gmrc(.js) - default is `${pwd}.gmrc`  [string]
+  --shadow      Applies migrations to shadow DB.      [boolean] [default: false]
+  --erase       This is your double opt-in to make it clear this DELETES
+                EVERYTHING.                           [boolean] [default: false]
 ```
 
 
@@ -352,7 +353,7 @@ output.
 
 Options:
   --help          Show help                                            [boolean]
-  --config Optional path to .gmrc(.js) - default is `${pwd}.gmrc`      [string]
+  --config, -c    Optional path to .gmrc(.js) - default is `${pwd}.gmrc`[string]
   --skipDatabase  Skip checks that require a database connection.
                                                       [boolean] [default: false]
 ```
@@ -367,9 +368,9 @@ Compiles a SQL file, inserting all the placeholders and returning the result to
 STDOUT
 
 Options:
-  --help    Show help                                                  [boolean]
-  --config Optional path to .gmrc(.js) - default is `${pwd}.gmrc`      [string]
-  --shadow  Apply shadow DB placeholders (for development).
+  --help        Show help                                              [boolean]
+  --config, -c  Optional path to .gmrc(.js) - default is `${pwd}.gmrc`  [string]
+  --shadow      Apply shadow DB placeholders (for development).
                                                       [boolean] [default: false]
 ```
 
@@ -386,7 +387,7 @@ run against the same database (via GM_DBURL envvar) unless --shadow or
 
 Options:
   --help          Show help                                            [boolean]
-  --config Optional path to .gmrc(.js) - default is `${pwd}.gmrc`      [string]
+  --config, -c    Optional path to .gmrc(.js) - default is `${pwd}.gmrc`[string]
   --shadow        Apply to the shadow database (for development).
                                                       [boolean] [default: false]
   --root          Run the file using the root user (but application database).

--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ Commands:
 
 Options:
   --help  Show help                                                    [boolean]
+  --config Optional path to .gmrc(.js) - default is `${pwd}.gmrc`      [string]
 
 You are running graphile-migrate v1.0.2.
 ```
@@ -239,6 +240,7 @@ Initializes a graphile-migrate project by creating a `.gmrc` file and
 
 Options:
   --help    Show help                                                  [boolean]
+  --config Optional path to .gmrc(.js) - default is `${pwd}.gmrc`      [string]
   --folder  Use a folder rather than a file for the current migration.
                                                       [boolean] [default: false]
 ```
@@ -254,6 +256,7 @@ For use in production and development.
 
 Options:
   --help          Show help                                            [boolean]
+  --config Optional path to .gmrc(.js) - default is `${pwd}.gmrc`      [string]
   --shadow        Apply migrations to the shadow DB (for development).
                                                       [boolean] [default: false]
   --forceActions  Run beforeAllMigrations and afterAllMigrations actions even if
@@ -271,6 +274,7 @@ migration, re-running it on any change. For development.
 
 Options:
   --help    Show help                                                  [boolean]
+  --config Optional path to .gmrc(.js) - default is `${pwd}.gmrc`      [string]
   --once    Runs the current migration and then exits.[boolean] [default: false]
   --shadow  Applies changes to shadow DB.             [boolean] [default: false]
 ```
@@ -286,6 +290,7 @@ current migration. Resets the shadow database.
 
 Options:
   --help         Show help                                             [boolean]
+  --config Optional path to .gmrc(.js) - default is `${pwd}.gmrc`      [string]
   --message, -m  Optional commit message to label migration, must not contain
                  newlines.                                              [string]
 ```
@@ -309,6 +314,7 @@ conflicts with other developers - be careful.
 
 Options:
   --help  Show help                                                    [boolean]
+  --config Optional path to .gmrc(.js) - default is `${pwd}.gmrc`      [string]
 ```
 
 
@@ -322,6 +328,7 @@ start. **HIGHLY DESTRUCTIVE**.
 
 Options:
   --help    Show help                                                  [boolean]
+  --config Optional path to .gmrc(.js) - default is `${pwd}.gmrc`      [string]
   --shadow  Applies migrations to shadow DB.          [boolean] [default: false]
   --erase   This is your double opt-in to make it clear this DELETES EVERYTHING.
                                                       [boolean] [default: false]
@@ -345,6 +352,7 @@ output.
 
 Options:
   --help          Show help                                            [boolean]
+  --config Optional path to .gmrc(.js) - default is `${pwd}.gmrc`      [string]
   --skipDatabase  Skip checks that require a database connection.
                                                       [boolean] [default: false]
 ```
@@ -360,6 +368,7 @@ STDOUT
 
 Options:
   --help    Show help                                                  [boolean]
+  --config Optional path to .gmrc(.js) - default is `${pwd}.gmrc`      [string]
   --shadow  Apply shadow DB placeholders (for development).
                                                       [boolean] [default: false]
 ```
@@ -377,6 +386,7 @@ run against the same database (via GM_DBURL envvar) unless --shadow or
 
 Options:
   --help          Show help                                            [boolean]
+  --config Optional path to .gmrc(.js) - default is `${pwd}.gmrc`      [string]
   --shadow        Apply to the shadow database (for development).
                                                       [boolean] [default: false]
   --root          Run the file using the root user (but application database).
@@ -489,6 +499,10 @@ opening brace `{` would be prepended with `module.exports =`:
 ```js
 module.exports = {
 ```
+
+All commands accept an optional `--config` parameter with a custom path to a
+`.gmrc(.js)` file. This is useful if, for example, you have a monorepo or other
+project with multiple interacting databases.
 
 ### Windows
 

--- a/__tests__/settings.test.ts
+++ b/__tests__/settings.test.ts
@@ -3,13 +3,12 @@ import "./helpers"; // Side effects - must come first
 import * as mockFs from "mock-fs";
 import * as path from "path";
 
+import { DEFAULT_GMRC_PATH, getSettings } from "../src/commands/_common";
 import {
   makeRootDatabaseConnectionString,
   ParsedSettings,
   parseSettings,
 } from "../src/settings";
-
-import { DEFAULT_GMRC_PATH, getSettings } from "../src/commands/_common";
 
 function sanitise(parsedSettings: ParsedSettings) {
   parsedSettings.migrationsFolder =

--- a/__tests__/settings.test.ts
+++ b/__tests__/settings.test.ts
@@ -9,6 +9,8 @@ import {
   parseSettings,
 } from "../src/settings";
 
+import { DEFAULT_GMRC_PATH, getSettings } from "../src/commands/_common";
+
 function sanitise(parsedSettings: ParsedSettings) {
   parsedSettings.migrationsFolder =
     "./" + path.relative(process.cwd(), parsedSettings.migrationsFolder);
@@ -276,5 +278,38 @@ describe("actions", () => {
             [Error: Errors occurred during settings validation:
             - Setting 'afterAllMigrations': Action spec of type 'unknown_value' not supported; perhaps you need to upgrade?]
           `);
+  });
+});
+
+describe("gmrc path", () => {
+  it("defaults to .gmrc", async () => {
+    mockFs.restore();
+    mockFs({
+      [DEFAULT_GMRC_PATH]: `
+        { "connectionString": "postgres://appuser:apppassword@host:5432/defaultdb" }
+      `,
+    });
+    const settings = await getSettings();
+    expect(settings.connectionString).toEqual(
+      "postgres://appuser:apppassword@host:5432/defaultdb",
+    );
+    mockFs.restore();
+  });
+
+  it("accepts an override and follows it", async () => {
+    mockFs.restore();
+    mockFs({
+      [DEFAULT_GMRC_PATH]: `
+        { "connectionString": "postgres://appuser:apppassword@host:5432/defaultdb" }
+      `,
+      ".other-gmrc": `
+        { "connectionString": "postgres://appuser:apppassword@host:5432/otherdb" }
+      `,
+    });
+    const settings = await getSettings(".other-gmrc");
+    expect(settings.connectionString).toEqual(
+      "postgres://appuser:apppassword@host:5432/otherdb",
+    );
+    mockFs.restore();
   });
 });

--- a/__tests__/settings.test.ts
+++ b/__tests__/settings.test.ts
@@ -305,7 +305,7 @@ describe("gmrc path", () => {
         { "connectionString": "postgres://appuser:apppassword@host:5432/otherdb" }
       `,
     });
-    const settings = await getSettings(".other-gmrc");
+    const settings = await getSettings({ configFile: ".other-gmrc" });
     expect(settings.connectionString).toEqual(
       "postgres://appuser:apppassword@host:5432/otherdb",
     );

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -78,6 +78,12 @@ yargs
   .command(wrapHandler(compileCommand))
   .command(wrapHandler(runCommand))
 
+  .option("config", {
+    alias: "c",
+    type: "string",
+    description: "Optional path to .gmrc(.js) - default is `${pwd}.gmrc`",
+  })
+
   .completion("completion", "Generate shell completion script.")
   .epilogue(
     process.env.GRAPHILE_SPONSOR

--- a/src/commands/_common.ts
+++ b/src/commands/_common.ts
@@ -9,7 +9,7 @@ export const DEFAULT_GMRC_PATH = `${process.cwd()}/.gmrc`;
 export const DEFAULT_GMRCJS_PATH = makeGmrcJsPath(DEFAULT_GMRC_PATH);
 
 // Used to type `argv` in all commands
-export type ConfigOptions = { config: string };
+export type ConfigOptions = { config?: string };
 
 export async function exists(path: string): Promise<boolean> {
   try {
@@ -34,28 +34,45 @@ export async function getSettingsFromJSON(path: string): Promise<Settings> {
   }
 }
 
-export async function getSettings(userGmrcPath?: string): Promise<Settings> {
-  const gmrcPath = userGmrcPath ?? DEFAULT_GMRC_PATH;
-  const gmrcJsPath = makeGmrcJsPath(gmrcPath);
+export async function getSettings({
+  configFile,
+}: { configFile?: string } = {}): Promise<Settings> {
+  let settings: Settings;
 
-  if (await exists(gmrcPath)) {
-    return getSettingsFromJSON(gmrcPath);
-  } else if (await exists(gmrcJsPath)) {
+  const tryRequire = (path: string): Settings => {
     try {
-      return require(gmrcJsPath);
+      return require(path);
     } catch (e) {
       throw new Error(
-        `Failed to import '${gmrcJsPath}'; error:\n    ${e.stack.replace(
+        `Failed to import '${DEFAULT_GMRCJS_PATH}'; error:\n    ${e.stack.replace(
           /\n/g,
           "\n    ",
         )}`,
       );
     }
+  };
+
+  if (configFile != null) {
+    if (!(await exists(configFile))) {
+      throw new Error(`Failed to import '${configFile}': file not found`);
+    }
+
+    if (configFile.endsWith(".js")) {
+      settings = tryRequire(configFile);
+    } else {
+      settings = await getSettingsFromJSON(configFile);
+    }
+  } else if (await exists(DEFAULT_GMRC_PATH)) {
+    settings = await getSettingsFromJSON(DEFAULT_GMRC_PATH);
+  } else if (await exists(DEFAULT_GMRCJS_PATH)) {
+    settings = tryRequire(DEFAULT_GMRCJS_PATH);
   } else {
     throw new Error(
       "No .gmrc file found; please run `graphile-migrate init` first.",
     );
   }
+
+  return settings;
 }
 
 export function readStdin(): Promise<string> {

--- a/src/commands/_common.ts
+++ b/src/commands/_common.ts
@@ -4,8 +4,12 @@ import { parse } from "pg-connection-string";
 
 import { Settings } from "../settings";
 
-export const GMRC_PATH = `${process.cwd()}/.gmrc`;
-export const GMRCJS_PATH = `${GMRC_PATH}.js`;
+export const makeGmrcJsPath = (gmrcPath: string): string => `${gmrcPath}.js`;
+export const DEFAULT_GMRC_PATH = `${process.cwd()}/.gmrc`;
+export const DEFAULT_GMRCJS_PATH = makeGmrcJsPath(DEFAULT_GMRC_PATH);
+
+// Used to type `argv` in all commands
+export type ConfigOptions = { config: string };
 
 export async function exists(path: string): Promise<boolean> {
   try {
@@ -30,15 +34,18 @@ export async function getSettingsFromJSON(path: string): Promise<Settings> {
   }
 }
 
-export async function getSettings(): Promise<Settings> {
-  if (await exists(GMRC_PATH)) {
-    return getSettingsFromJSON(GMRC_PATH);
-  } else if (await exists(GMRCJS_PATH)) {
+export async function getSettings(userGmrcPath?: string): Promise<Settings> {
+  const gmrcPath = userGmrcPath ?? DEFAULT_GMRC_PATH;
+  const gmrcJsPath = makeGmrcJsPath(gmrcPath);
+
+  if (await exists(gmrcPath)) {
+    return getSettingsFromJSON(gmrcPath);
+  } else if (await exists(gmrcJsPath)) {
     try {
-      return require(GMRCJS_PATH);
+      return require(gmrcJsPath);
     } catch (e) {
       throw new Error(
-        `Failed to import '${GMRCJS_PATH}'; error:\n    ${e.stack.replace(
+        `Failed to import '${gmrcJsPath}'; error:\n    ${e.stack.replace(
           /\n/g,
           "\n    ",
         )}`,

--- a/src/commands/commit.ts
+++ b/src/commands/commit.ts
@@ -151,6 +151,6 @@ export const commitCommand: CommandModule<
     if (argv.message !== undefined && !argv.message) {
       throw new Error("Missing or empty commit message after --message flag");
     }
-    await commit(await getSettings(argv.config), argv.message);
+    await commit(await getSettings({ configFile: argv.config }), argv.message);
   },
 };

--- a/src/commands/commit.ts
+++ b/src/commands/commit.ts
@@ -17,7 +17,7 @@ import {
 } from "../migration";
 import { ParsedSettings, parseSettings, Settings } from "../settings";
 import { sluggify } from "../sluggify";
-import { getSettings } from "./_common";
+import { ConfigOptions, getSettings } from "./_common";
 import { _migrate } from "./migrate";
 import { _reset } from "./reset";
 
@@ -132,7 +132,7 @@ export const commitCommand: CommandModule<
   never,
   {
     message?: string;
-  }
+  } & ConfigOptions
 > = {
   command: "commit",
   aliases: [],
@@ -151,6 +151,6 @@ export const commitCommand: CommandModule<
     if (argv.message !== undefined && !argv.message) {
       throw new Error("Missing or empty commit message after --message flag");
     }
-    await commit(await getSettings(), argv.message);
+    await commit(await getSettings(argv.config), argv.message);
   },
 };

--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -32,7 +32,7 @@ Compiles a SQL file, inserting all the placeholders and returning the result to 
     },
   },
   handler: async argv => {
-    const settings = await getSettings(argv.config);
+    const settings = await getSettings({ configFile: argv.config });
     const content =
       typeof argv.file === "string"
         ? await fsp.readFile(argv.file, "utf8")

--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -3,7 +3,7 @@ import { CommandModule } from "yargs";
 
 import { compilePlaceholders } from "../migration";
 import { parseSettings, Settings } from "../settings";
-import { getSettings, readStdin } from "./_common";
+import { ConfigOptions, getSettings, readStdin } from "./_common";
 
 export async function compile(
   settings: Settings,
@@ -18,7 +18,7 @@ export const compileCommand: CommandModule<
   {},
   {
     shadow?: boolean;
-  }
+  } & ConfigOptions
 > = {
   command: "compile [file]",
   aliases: [],
@@ -32,7 +32,7 @@ Compiles a SQL file, inserting all the placeholders and returning the result to 
     },
   },
   handler: async argv => {
-    const settings = await getSettings();
+    const settings = await getSettings(argv.config);
     const content =
       typeof argv.file === "string"
         ? await fsp.readFile(argv.file, "utf8")

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -6,18 +6,23 @@ import { CommandModule } from "yargs";
 import { version } from "../../package.json";
 import { getCurrentMigrationLocation, writeCurrentMigration } from "../current";
 import { parseSettings } from "../settings";
-import { exists, getSettings, GMRC_PATH, GMRCJS_PATH } from "./_common";
+import {
+  DEFAULT_GMRC_PATH,
+  DEFAULT_GMRCJS_PATH,
+  exists,
+  getSettings,
+} from "./_common";
 
 interface InitOptions {
   folder?: boolean;
 }
 
 export async function init(options: InitOptions = {}): Promise<void> {
-  if (await exists(GMRC_PATH)) {
-    throw new Error(`.gmrc file already exists at ${GMRC_PATH}`);
+  if (await exists(DEFAULT_GMRC_PATH)) {
+    throw new Error(`.gmrc file already exists at ${DEFAULT_GMRC_PATH}`);
   }
-  if (await exists(GMRCJS_PATH)) {
-    throw new Error(`.gmrc.js file already exists at ${GMRCJS_PATH}`);
+  if (await exists(DEFAULT_GMRCJS_PATH)) {
+    throw new Error(`.gmrc.js file already exists at ${DEFAULT_GMRCJS_PATH}`);
   }
   const dbStrings =
     process.env.DATABASE_URL &&
@@ -57,7 +62,7 @@ export async function init(options: InitOptions = {}): Promise<void> {
 `;
 
   await fsp.writeFile(
-    GMRC_PATH,
+    DEFAULT_GMRC_PATH,
     `\
 /*
  * Graphile Migrate configuration.
@@ -178,7 +183,7 @@ export async function init(options: InitOptions = {}): Promise<void> {
   );
   // eslint-disable-next-line
   console.log(
-    `Template .gmrc file written to '${GMRC_PATH}'; please read and edit it to suit your needs.`,
+    `Template .gmrc file written to '${DEFAULT_GMRC_PATH}'; please read and edit it to suit your needs.`,
   );
   const settings = await getSettings();
   const parsedSettings = await parseSettings({

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -110,7 +110,7 @@ export const migrateCommand: CommandModule<
   },
   handler: async argv => {
     await migrate(
-      await getSettings(argv.config),
+      await getSettings({ configFile: argv.config }),
       argv.shadow,
       argv.forceActions,
     );

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -86,6 +86,7 @@ export async function migrate(
 export const migrateCommand: CommandModule<
   never,
   {
+    config: string;
     shadow: boolean;
     forceActions: boolean;
   }
@@ -108,6 +109,10 @@ export const migrateCommand: CommandModule<
     },
   },
   handler: async argv => {
-    await migrate(await getSettings(), argv.shadow, argv.forceActions);
+    await migrate(
+      await getSettings(argv.config),
+      argv.shadow,
+      argv.forceActions,
+    );
   },
 };

--- a/src/commands/reset.ts
+++ b/src/commands/reset.ts
@@ -3,7 +3,7 @@ import { CommandModule } from "yargs";
 import { executeActions } from "../actions";
 import { escapeIdentifier, withClient } from "../pg";
 import { ParsedSettings, parseSettings, Settings } from "../settings";
-import { getSettings } from "./_common";
+import { ConfigOptions, getSettings } from "./_common";
 import { _migrate } from "./migrate";
 
 export async function _reset(
@@ -64,7 +64,7 @@ export const resetCommand: CommandModule<
   {
     shadow: boolean;
     erase: boolean;
-  }
+  } & ConfigOptions
 > = {
   command: "reset",
   aliases: [],
@@ -91,6 +91,6 @@ export const resetCommand: CommandModule<
       );
       process.exit(2);
     }
-    await reset(await getSettings(), argv.shadow);
+    await reset(await getSettings(argv.config), argv.shadow);
   },
 };

--- a/src/commands/reset.ts
+++ b/src/commands/reset.ts
@@ -91,6 +91,6 @@ export const resetCommand: CommandModule<
       );
       process.exit(2);
     }
-    await reset(await getSettings(argv.config), argv.shadow);
+    await reset(await getSettings({ configFile: argv.config }), argv.shadow);
   },
 };

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -87,7 +87,7 @@ Compiles a SQL file, inserting all the placeholders, and then runs it against th
     },
   },
   handler: async argv => {
-    const defaultSettings = await getSettings(argv.config);
+    const defaultSettings = await getSettings({ configFile: argv.config });
 
     // `run` might be called from an action; in this case `DATABASE_URL` will
     // be unavailable (overwritten with DO_NOT_USE_DATABASE_URL) to avoid

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -10,7 +10,12 @@ import {
   parseSettings,
   Settings,
 } from "../settings";
-import { getDatabaseName, getSettings, readStdin } from "./_common";
+import {
+  ConfigOptions,
+  getDatabaseName,
+  getSettings,
+  readStdin,
+} from "./_common";
 
 export async function run(
   settings: Settings,
@@ -56,7 +61,7 @@ export const runCommand: CommandModule<
     shadow?: boolean;
     root?: boolean;
     rootDatabase?: boolean;
-  }
+  } & ConfigOptions
 > = {
   command: "run [file]",
   aliases: [],
@@ -82,7 +87,7 @@ Compiles a SQL file, inserting all the placeholders, and then runs it against th
     },
   },
   handler: async argv => {
-    const defaultSettings = await getSettings();
+    const defaultSettings = await getSettings(argv.config);
 
     // `run` might be called from an action; in this case `DATABASE_URL` will
     // be unavailable (overwritten with DO_NOT_USE_DATABASE_URL) to avoid

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -5,7 +5,7 @@ import { getCurrentMigrationLocation, readCurrentMigration } from "../current";
 import { getLastMigration, getMigrationsAfter } from "../migration";
 import { withClient } from "../pg";
 import { ParsedSettings, parseSettings, Settings } from "../settings";
-import { getSettings } from "./_common";
+import { ConfigOptions, getSettings } from "./_common";
 
 interface Status {
   remainingMigrations?: Array<string>;
@@ -60,7 +60,10 @@ export async function status(
   return _status(parsedSettings, options);
 }
 
-export const statusCommand: CommandModule<never, StatusOptions> = {
+export const statusCommand: CommandModule<
+  never,
+  StatusOptions & ConfigOptions
+> = {
   command: "status",
   aliases: [],
   describe: `\
@@ -81,7 +84,7 @@ are true, exit status will be 0 (success). Additional messages may also be outpu
   handler: async argv => {
     /* eslint-disable no-console */
     let exitCode = 0;
-    const details = await status(await getSettings(), argv);
+    const details = await status(await getSettings(argv.config), argv);
     if (details.remainingMigrations) {
       const remainingCount = details.remainingMigrations?.length;
       if (remainingCount > 0) {

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -84,7 +84,10 @@ are true, exit status will be 0 (success). Additional messages may also be outpu
   handler: async argv => {
     /* eslint-disable no-console */
     let exitCode = 0;
-    const details = await status(await getSettings(argv.config), argv);
+    const details = await status(
+      await getSettings({ configFile: argv.config }),
+      argv,
+    );
     if (details.remainingMigrations) {
       const remainingCount = details.remainingMigrations?.length;
       if (remainingCount > 0) {

--- a/src/commands/uncommit.ts
+++ b/src/commands/uncommit.ts
@@ -14,7 +14,7 @@ import {
   undoMigration,
 } from "../migration";
 import { ParsedSettings, parseSettings, Settings } from "../settings";
-import { getSettings } from "./_common";
+import { ConfigOptions, getSettings } from "./_common";
 import { _migrate } from "./migrate";
 import { _reset } from "./reset";
 
@@ -64,7 +64,7 @@ export async function uncommit(settings: Settings): Promise<void> {
   return _uncommit(parsedSettings);
 }
 
-export const uncommitCommand: CommandModule<never, {}> = {
+export const uncommitCommand: CommandModule<never, ConfigOptions> = {
   command: "uncommit",
   aliases: [],
   describe:
@@ -74,6 +74,6 @@ export const uncommitCommand: CommandModule<never, {}> = {
     if (argv.message !== undefined && !argv.message) {
       throw new Error("Missing or empty commit message after --message flag");
     }
-    await uncommit(await getSettings());
+    await uncommit(await getSettings(argv.config));
   },
 };

--- a/src/commands/uncommit.ts
+++ b/src/commands/uncommit.ts
@@ -74,6 +74,6 @@ export const uncommitCommand: CommandModule<never, ConfigOptions> = {
     if (argv.message !== undefined && !argv.message) {
       throw new Error("Missing or empty commit message after --message flag");
     }
-    await uncommit(await getSettings(argv.config));
+    await uncommit(await getSettings({ configFile: argv.config }));
   },
 };

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -14,7 +14,7 @@ import {
   readCurrentMigration,
   writeCurrentMigration,
 } from "../current";
-import { getSettings } from "./_common";
+import { ConfigOptions, getSettings } from "./_common";
 
 export function _makeCurrentMigrationRunner(
   parsedSettings: ParsedSettings,
@@ -245,7 +245,7 @@ export const watchCommand: CommandModule<
   {
     once: boolean;
     shadow: boolean;
-  }
+  } & ConfigOptions
 > = {
   command: "watch",
   aliases: [],
@@ -264,6 +264,6 @@ export const watchCommand: CommandModule<
     },
   },
   handler: async argv => {
-    await watch(await getSettings(), argv.once, argv.shadow);
+    await watch(await getSettings(argv.config), argv.once, argv.shadow);
   },
 };

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -264,6 +264,10 @@ export const watchCommand: CommandModule<
     },
   },
   handler: async argv => {
-    await watch(await getSettings(argv.config), argv.once, argv.shadow);
+    await watch(
+      await getSettings({ configFile: argv.config }),
+      argv.once,
+      argv.shadow,
+    );
   },
 };


### PR DESCRIPTION
## Description

Solution for https://github.com/graphile/migrate/issues/102 – adds `--config` option to all CLI commands which tells `graphile-migrate` where to look for `.gmrc`.

## Performance impact

Neglible.

## Security impact

Unknown

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [x] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
