### PR TITLE
fix: trigger watch on symlink addition/removal in current/ folder

### DIFF
--- a/__tests__/commit.test.ts
+++ b/__tests__/commit.test.ts
@@ -117,7 +117,7 @@ describe.each([[undefined], ["My Commit Message"]])(
     it("can commit multi-file migration", async () => {
       mockFs({
         [`migrations/committed/000001${commitMessageSlug}.sql`]: MIGRATION_1_COMMITTED,
-        "migrations/current": MIGRATION_MULTIFILE_FILES,
+        ...MIGRATION_MULTIFILE_FILES,
       });
 
       await commit(settings, commitMessage);
@@ -138,7 +138,7 @@ describe.each([[undefined], ["My Commit Message"]])(
     it("throws on invalid message", async () => {
       mockFs({
         [`migrations/committed/000001${commitMessageSlug}.sql`]: MIGRATION_1_COMMITTED,
-        "migrations/current": MIGRATION_MULTIFILE_FILES,
+        ...MIGRATION_MULTIFILE_FILES,
       });
 
       const promise = commit(

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -255,9 +255,14 @@ export const makeMigrations = (commitMessage?: string) => {
   }\n\n${MIGRATION_NOTRX_TEXT.trim()}\n`;
 
   const MIGRATION_MULTIFILE_FILES = {
-    "001.sql": "select 1;",
-    "002-two.sql": "select 2;",
-    "003.sql": "select 3;",
+    "migrations/links/two.sql": "select 2;",
+    "migrations/current": {
+      "001.sql": "select 1;",
+      "002-two.sql": mockFs.symlink({
+        path: "../links/two.sql",
+      }),
+      "003.sql": "select 3;",
+    },
   };
 
   const MIGRATION_MULTIFILE_TEXT = `\

--- a/__tests__/uncommit.test.ts
+++ b/__tests__/uncommit.test.ts
@@ -109,14 +109,17 @@ describe.each([[undefined], ["My Commit Message"]])(
       });
       expect(await fsp.readFile("migrations/current/001.sql", "utf8")).toEqual(
         (commitMessage ? `--! Message: ${commitMessage}\n\n` : "") +
-          MIGRATION_MULTIFILE_FILES["001.sql"].trim() +
+          MIGRATION_MULTIFILE_FILES["migrations/current"]["001.sql"].trim() +
           "\n",
       );
       expect(
         await fsp.readFile("migrations/current/002-two.sql", "utf8"),
-      ).toEqual(MIGRATION_MULTIFILE_FILES["002-two.sql"].trim() + "\n");
+      ).toEqual(
+        MIGRATION_MULTIFILE_FILES["migrations/links/two.sql"].trim() + "\n",
+      );
       expect(await fsp.readFile("migrations/current/003.sql", "utf8")).toEqual(
-        MIGRATION_MULTIFILE_FILES["003.sql"].trim() + "\n",
+        MIGRATION_MULTIFILE_FILES["migrations/current"]["003.sql"].trim() +
+          "\n",
       );
 
       await commit(settings);

--- a/__tests__/watch.test.ts
+++ b/__tests__/watch.test.ts
@@ -2,8 +2,11 @@ jest.mock("child_process");
 
 import "./helpers"; // Has side-effects; must come first
 
+import * as mockFs from "mock-fs";
+
 import { _makeCurrentMigrationRunner, _watch } from "../src/commands/watch";
 import { parseSettings } from "../src/settings";
+import { makeMigrations } from "./helpers";
 import {
   makeActionSpies,
   mockCurrentSqlContentOnce,
@@ -13,6 +16,8 @@ import {
 } from "./helpers";
 
 beforeEach(resetDb);
+
+const { MIGRATION_MULTIFILE_FILES } = makeMigrations();
 
 it("doesn't run current.sql if it's already up to date", async () => {
   const { settings, getActionCalls } = makeActionSpies();
@@ -56,6 +61,57 @@ SELECT ':DATABASE_NAME';
 SELECT ':DATABASE_NAME', 2 * 2;
 `,
   );
+  await migrationRunner();
+  expect(getActionCalls()).toEqual([
+    "beforeCurrent",
+    "afterCurrent",
+    "beforeCurrent",
+    "afterCurrent",
+  ]);
+});
+
+it("watches symlinked files", async () => {
+  const { settings, getActionCalls } = makeActionSpies();
+  const parsedSettings = await parseSettings({
+    connectionString: TEST_DATABASE_URL,
+    ...settings,
+  });
+  await setup(parsedSettings);
+  const migrationRunner = _makeCurrentMigrationRunner(
+    parsedSettings,
+    false,
+    false,
+  );
+
+  expect(getActionCalls()).toEqual([]);
+  mockFs({
+    ...MIGRATION_MULTIFILE_FILES,
+    "migrations/links/two.sql": `\
+-- First migration
+SELECT ':DATABASE_NAME';
+`,
+  });
+  await migrationRunner();
+  expect(getActionCalls()).toEqual(["beforeCurrent", "afterCurrent"]);
+
+  // This one is identical
+  mockFs({
+    ...MIGRATION_MULTIFILE_FILES,
+    "migrations/links/two.sql": `\
+-- Second migration; identical except for this comment
+SELECT ':DATABASE_NAME';
+`,
+  });
+  await migrationRunner();
+  expect(getActionCalls()).toEqual(["beforeCurrent", "afterCurrent"]);
+
+  mockFs({
+    ...MIGRATION_MULTIFILE_FILES,
+    "migrations/links/two.sql": `\
+-- Third migration; DIFFERENT!
+SELECT ':DATABASE_NAME', 2 * 2;
+`,
+  });
   await migrationRunner();
   expect(getActionCalls()).toEqual([
     "beforeCurrent",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@types/node": "^14.6.0",
     "@types/pg": "^7.14.1",
     "chalk": "^3.0.0",
-    "chokidar": "^3.3.1",
+    "chokidar": "^3.5.1",
     "json5": "^2.1.2",
     "pg": ">=6.5 <9",
     "pg-connection-string": "^2.1.0",

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -224,8 +224,12 @@ export async function _watch(
         stabilityThreshold: 200,
         pollInterval: 100,
       },
+
+      ignoreInitial: true,
     });
+    watcher.on("add", queue);
     watcher.on("change", queue);
+    watcher.on("unlink", queue);
     queue();
     return Promise.resolve();
   }

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -225,12 +225,16 @@ export async function _watch(
         pollInterval: 100,
       },
 
+      /*
+       * We don't want to run the queue too many times during startup; so we
+       * call it once on the 'ready' event.
+       */
       ignoreInitial: true,
     });
     watcher.on("add", queue);
     watcher.on("change", queue);
     watcher.on("unlink", queue);
-    queue();
+    watcher.once("ready", queue);
     return Promise.resolve();
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -420,12 +420,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*":
-  version "13.9.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.9.1.tgz#96f606f8cd67fb018847d9b61e93997dabdefc72"
-  integrity sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ==
-
-"@types/node@^14.6.0":
+"@types/node@*", "@types/node@^14.6.0":
   version "14.6.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.6.0.tgz#7d4411bf5157339337d7cff864d9ff45f177b499"
   integrity sha512-mikldZQitV94akrc4sCcSjtJfsTKt4p+e/s0AGscVA6XArQ9kFclP+ZiYUMnq987rc6QlYxXv/EivqlfSLxpKA==
@@ -905,10 +900,10 @@ chardet@^0.7.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
-chokidar@^3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.3.1.tgz#c84e5b3d18d9a4d77558fef466b1bf16bbeb3450"
-  integrity sha512-4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==
+chokidar@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.1.tgz#ee9ce7bbebd2b79f49f304799d5468e31e14e68a"
+  integrity sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==
   dependencies:
     anymatch "~3.1.1"
     braces "~3.0.2"
@@ -916,9 +911,9 @@ chokidar@^3.3.1:
     is-binary-path "~2.1.0"
     is-glob "~4.0.1"
     normalize-path "~3.0.0"
-    readdirp "~3.3.0"
+    readdirp "~3.5.0"
   optionalDependencies:
-    fsevents "~2.1.2"
+    fsevents "~2.3.1"
 
 ci-info@^2.0.0:
   version "2.0.0"
@@ -1710,10 +1705,10 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
-fsevents@^2.1.2, fsevents@~2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.2.tgz#4c0a1fb34bc68e543b4b82a9ec392bfbda840805"
-  integrity sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==
+fsevents@^2.1.2, fsevents@~2.3.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
 function-bind@^1.1.1:
   version "1.1.1"
@@ -3303,10 +3298,10 @@ pgpass@1.x:
   dependencies:
     split "^1.0.0"
 
-picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.0.7:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.1.tgz#21bac888b6ed8601f831ce7816e335bc779f0a4a"
-  integrity sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==
+picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.3.tgz#465547f359ccc206d3c48e46a1bcb89bf7ee619d"
+  integrity sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==
 
 pify@^2.0.0:
   version "2.3.0"
@@ -3451,12 +3446,12 @@ read-pkg@^2.0.0:
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
 
-readdirp@~3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.3.0.tgz#984458d13a1e42e2e9f5841b129e162f369aff17"
-  integrity sha512-zz0pAkSPOXXm1viEwygWIPSPkcBYjW1xU5j/JBh5t9bGCJwa6f9+BJa6VaB2g+b55yVrmXzqkyLf4xaWYM0IkQ==
+readdirp@~3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.5.0.tgz#9ba74c019b15d365278d2e91bb8c48d7b4d42c9e"
+  integrity sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==
   dependencies:
-    picomatch "^2.0.7"
+    picomatch "^2.2.1"
 
 realpath-native@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
## Description

It seems we previously weren't picking up these events (relying only on `change` as we did), so we didn't notice symlinks being added or removed from the `current/` directory. This PR resolves that.

I've also added tests, but they all already passed... so... not super helpful. I could not reproduce this bad behaviour in tests.

## Performance impact

Negligible, watch mode only.

## Security impact

Watch mode only, user controls filesystem, no impact expected.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [x] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
