### PR TITLE
Support .cjs config files

### DIFF
--- a/src/commands/_common.ts
+++ b/src/commands/_common.ts
@@ -7,6 +7,7 @@ import { Settings } from "../settings";
 
 export const DEFAULT_GMRC_PATH = `${process.cwd()}/.gmrc`;
 export const DEFAULT_GMRCJS_PATH = `${DEFAULT_GMRC_PATH}.js`;
+export const DEFAULT_GMRCCJS_PATH = `${DEFAULT_GMRC_PATH}.cjs`;
 
 /**
  * Represents the option flags that are valid for all commands (see
@@ -86,7 +87,7 @@ export async function getSettings(options: Options = {}): Promise<Settings> {
       throw new Error(`Failed to import '${configFile}': file not found`);
     }
 
-    if (configFile.endsWith(".js")) {
+    if (configFile.endsWith(".js") || configFile.endsWith(".cjs")) {
       return tryRequire(configFile);
     } else {
       return await getSettingsFromJSON(configFile);
@@ -95,6 +96,8 @@ export async function getSettings(options: Options = {}): Promise<Settings> {
     return await getSettingsFromJSON(DEFAULT_GMRC_PATH);
   } else if (await exists(DEFAULT_GMRCJS_PATH)) {
     return tryRequire(DEFAULT_GMRCJS_PATH);
+  } else if (await exists(DEFAULT_GMRCCJS_PATH)) {
+    return tryRequire(DEFAULT_GMRCCJS_PATH);
   } else {
     throw new Error(
       "No .gmrc file found; please run `graphile-migrate init` first.",

--- a/src/commands/_common.ts
+++ b/src/commands/_common.ts
@@ -72,7 +72,7 @@ export async function getSettings(options: Options = {}): Promise<Settings> {
     const relativePath = resolve(process.cwd(), path);
 
     try {
-      return relativePath.endsWith(".mjs") ? import(relativePath) : require(relativePath);
+      return relativePath.endsWith(".mjs") ? await import(relativePath) : require(relativePath);
     } catch (e) {
       throw new Error(
         `Failed to import '${relativePath}'; error:\n    ${e.stack.replace(

--- a/src/commands/_common.ts
+++ b/src/commands/_common.ts
@@ -8,6 +8,7 @@ import { Settings } from "../settings";
 export const DEFAULT_GMRC_PATH = `${process.cwd()}/.gmrc`;
 export const DEFAULT_GMRCJS_PATH = `${DEFAULT_GMRC_PATH}.js`;
 export const DEFAULT_GMRCCJS_PATH = `${DEFAULT_GMRC_PATH}.cjs`;
+export const DEFAULT_GMRCMJS_PATH = `${DEFAULT_GMRC_PATH}.mjs`;
 
 /**
  * Represents the option flags that are valid for all commands (see
@@ -71,7 +72,7 @@ export async function getSettings(options: Options = {}): Promise<Settings> {
     const relativePath = resolve(process.cwd(), path);
 
     try {
-      return require(relativePath);
+      return relativePath.endsWith(".mjs") ? import(relativePath) : require(relativePath);
     } catch (e) {
       throw new Error(
         `Failed to import '${relativePath}'; error:\n    ${e.stack.replace(
@@ -87,7 +88,7 @@ export async function getSettings(options: Options = {}): Promise<Settings> {
       throw new Error(`Failed to import '${configFile}': file not found`);
     }
 
-    if (configFile.endsWith(".js") || configFile.endsWith(".cjs")) {
+    if (configFile.endsWith(".js") || configFile.endsWith(".cjs") || configFile.endsWith(".mjs")) {
       return tryRequire(configFile);
     } else {
       return await getSettingsFromJSON(configFile);
@@ -98,6 +99,8 @@ export async function getSettings(options: Options = {}): Promise<Settings> {
     return tryRequire(DEFAULT_GMRCJS_PATH);
   } else if (await exists(DEFAULT_GMRCCJS_PATH)) {
     return tryRequire(DEFAULT_GMRCCJS_PATH);
+  } else if (await exists(DEFAULT_GMRCMJS_PATH)) {
+    return tryRequire(DEFAULT_GMRCMJS_PATH);
   } else {
     throw new Error(
       "No .gmrc file found; please run `graphile-migrate init` first.",


### PR DESCRIPTION
## Description

Hello,

This is a quick* fix the use of JS config files in projects where `"type": "module"` is used in `package.json` (which will me more and more frequent now that Node 10 obsolete).
Cheers!
*The right way might be to support it via `import`

## Performance impact

None

## Security impact

None

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.

(not sure if that's something worth mentioning in README):
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.