### PR TITLE
docs: using Migrate with an existing database

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,11 @@ unaffected by the iteration you've been applying to your development database
 
 ### Getting started
 
+> These instructions are for starting a new database project with Graphile
+> Migrate; if you already have a database schema, see
+> [Using Migrate with an existing database](#using-migrate-with-an-existing-database)
+> for some tips.
+
 Create your database role (if desired), database and shadow database:
 
 ```bash
@@ -141,9 +146,6 @@ these environmental variables to a file so you can easily source them (with the
 . ./.env
 graphile-migrate watch
 ```
-
-If you already have a database schema, see [Using Migrate with an existing
-database](#using-migrate-with-an-existing-database) for some tips.
 
 ## Usage
 
@@ -662,8 +664,8 @@ on in parallel no additional `rollback` step is required. When you
 indexes, etc) once the dropped entity has been replaced. Reviewing the database
 schema diff can help you spot these issues.
 
-More examples of idempotent operations can be found in [docs/idempotent-examples.md](./docs/idempotent-examples.md).
-
+More examples of idempotent operations can be found in
+[docs/idempotent-examples.md](./docs/idempotent-examples.md).
 
 ## Disable Transaction
 
@@ -849,31 +851,66 @@ $$ language sql stable;
 
 ## Using Migrate with an existing database
 
-It's possible to use Graphile Migrate with an existing production system. In
-this case you'll already have one or several production database instances with
-an existing schema (let's call it `initial_schema.sql`).
+You can use Graphile Migrate to manage the migrations for your existing system,
+but the process is slightly different.
 
-We can't manage `initial_schema.sql` as the first migration because this would
-reset the state of the production database. Instead, we want the first
-migration to be applied *on top* of `initial_schema.sql`.
+Because Graphile Migrate tracks which migrations it has ran and runs remaining
+migrations, you must not put your existing database schema as the first
+migration otherwise you production database might be wiped (or it just won't
+work) when Graphile Migrate attempts to apply it. Instead you must ensure all
+databases (development, staging, production, etc.) are at the same state before
+running any migrations, and then the Graphile Migrate migrations will be applied
+_on top_ of this initial state.
 
-However, we also want:
-* The shadow database to be initialized with `initial_schema.sql`
-* New development and production databases to be initialized with `initial_schema.sql`
+### Storing the initial state
 
-To get the shadow database initialized, you can add the initial schema in an
-`afterReset` hook such as `"afterReset": [ "initial_schema.sql" ]`. `afterReset`
-is only used when a DB is reset (i.e. when you have Graphile Migrate create it)
-and thus it won't be a concern for production since you never run reset there.
+Though you could hand-roll the initial state if you prefer, we generally advise
+that you take a schema-only dump of your existing (production) database schema
+and store it to `migrations/initial_schema.sql` with a command such as:
 
-To initialize new development and production databases you could then run
-`graphile-migrate reset` as part of initializing the new database instance.
-However in some deployment environments (eg, deploying a new application to an
-existing database server) it may be best to check whether the target database
-schema is empty first or avoid `reset` entirely by using an external mechanism
-to apply `initial_schema.sql`. For example, the [official postgres docker
-container](https://hub.docker.com/_/postgres) has the
-`/docker-entrypoint-initdb.d/` directory for initialization scripts.
+```
+pg_dump --schema-only --no-owner --file=migrations/initial_schema.sql "postgres://..."
+```
+
+If you manage some of the data in your initial database schema using your
+existing migration system then you should add that data to your
+`initial_schema.sql` file too.
+
+### New databases must apply the initial state
+
+When creating new databases (e.g. test databases, new development databases for
+new developers, when resetting your development database, whenever Graphile
+Migrate recreates the shadow database, etc.) it's imperative that these new
+databases also have `initial_schema.sql` applied to them.
+
+#### Applying the initial schema with Actions
+
+One way to apply the initial schema is to use [Actions](#actions), specifically
+the `afterReset` action, to apply the initial schema immediately after the
+database is reset/created and before any committed migrations are applied. Add
+something like `"afterReset": [ "initial_schema.sql" ]` to your `.gmrc` and
+whenever Graphile Migrate's `reset` command runs (including against the shadow
+database when committing a migration) this initial schema will be applied. Note
+this is only used when a DB is reset (i.e. when you have Graphile Migrate create
+it) and thus it won't be a concern for production since you never run `reset`
+there.
+
+#### Applying the initial schema in other ways
+
+You can take care of applying the initial schema using your own tooling should
+you want or need to do so.
+
+The [official PostgreSQL Docker container](https://hub.docker.com/_/postgres)
+has the `/docker-entrypoint-initdb.d/` directory for initialization scripts, and
+this might be a good location for your `initial_schema.sql` file if you're using
+this image.
+
+**Important note**: in development the shadow database must be able to be
+destroyed and recreated by Graphile Migrate at will, so applying the initial
+schema _to the shadow database_ must be done via an Action (see above). You can,
+however, ensure that your action only applies to the shadow database by setting
+the `"shadow": true` property, leaving you free to manage how your more
+permanent databases are initialized.
 
 ## TODO:
 
@@ -886,5 +923,5 @@ container](https://hub.docker.com/_/postgres) has the
 
 - [ ] Add `graphile-migrate import` command: used after init but before running
       any other commands, imports the existing database as if it were the first
-      migration. (For now just pg_dump, and put the schema in
-      migrations/schema.sql.)
+      migration. (For now, see
+      [Using Migrate with an existing database](#using-migrate-with-an-existing-database).)

--- a/README.md
+++ b/README.md
@@ -142,6 +142,9 @@ these environmental variables to a file so you can easily source them (with the
 graphile-migrate watch
 ```
 
+If you already have a database schema, see [Using Migrate with an existing
+database](#using-migrate-with-an-existing-database) for some tips.
+
 ## Usage
 
 ### Committed and current migrations
@@ -843,6 +846,34 @@ create function get_random_number() returns int as $$
   select 4;
 $$ language sql stable;
 ```
+
+## Using Migrate with an existing database
+
+It's possible to use Graphile Migrate with an existing production system. In
+this case you'll already have one or several production database instances with
+an existing schema (let's call it `initial_schema.sql`).
+
+We can't manage `initial_schema.sql` as the first migration because this would
+reset the state of the production database. Instead, we want the first
+migration to be applied *on top* of `initial_schema.sql`.
+
+However, we also want:
+* The shadow database to be initialized with `initial_schema.sql`
+* New development and production databases to be initialized with `initial_schema.sql`
+
+To get the shadow database initialized, you can add the initial schema in an
+`afterReset` hook such as `"afterReset": [ "initial_schema.sql" ]`. `afterReset`
+is only used when a DB is reset (i.e. when you have Graphile Migrate create it)
+and thus it won't be a concern for production since you never run reset there.
+
+To initialize new development and production databases you could then run
+`graphile-migrate reset` as part of initializing the new database instance.
+However in some deployment environments (eg, deploying a new application to an
+existing database server) it may be best to check whether the target database
+schema is empty first or avoid `reset` entirely by using an external mechanism
+to apply `initial_schema.sql`. For example, the [official postgres docker
+container](https://hub.docker.com/_/postgres) has the
+`/docker-entrypoint-initdb.d/` directory for initialization scripts.
 
 ## TODO:
 


### PR DESCRIPTION
Here's some documentation covering the questions I asked in #121.

One point we didn't discuss in #121 was how to initialize new production and development databases with the `initial_schema.sql` already in use in production. In our production tooling I found `graphile-migrate reset` too scary to use for applying `initial_schema.sql`, as our application is occasionally deployed to existing database servers. In theory this should be ok as we'd be using a schema name not already in use. But in practice I wanted some extra defense against things going wrong, so I've added an alternative suggestion on how to do this.

(Possibly this suggests a feature for the future — allow a safe `graphile-migrate reset` without `-f`, provided the schema doesn't already exist or is empty.)