### PR TITLE
Add example Docker file and wrapper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -912,6 +912,13 @@ however, ensure that your action only applies to the shadow database by setting
 the `"shadow": true` property, leaving you free to manage how your more
 permanent databases are initialized.
 
+
+## Examples
+
+- [Running Graphile Migrate in a Docker container](docs/docker/README.md)
+- [Examples of idempotent migration files including edge cases](docs/idempotent-examples.md)
+
+
 ## TODO:
 
 - [ ] Store pgSettings with committed transactions to protect against user edits

--- a/docs/docker/Dockerfile
+++ b/docs/docker/Dockerfile
@@ -1,0 +1,25 @@
+FROM ubuntu:20.04
+
+ARG NODEJS_VERSION=14
+ARG POSTGRES_VERSION=12
+
+RUN apt-get update && \
+    apt-get install -y \
+    curl
+
+# Install postgres client tools
+RUN apt-get update && \
+    apt-get install -y \
+    postgresql-client-${POSTGRES_VERSION}
+
+# Install nodejs via nodesource.
+RUN curl -fsSL https://deb.nodesource.com/setup_${NODEJS_VERSION}.x | bash -
+RUN apt-get install -y nodejs
+
+# Latest version of graphile-migrate
+RUN npm install -g graphile-migrate
+
+# Default working directory. Map your migrations folder in here with `docker -v`
+WORKDIR /migrate
+
+ENTRYPOINT ["/usr/bin/graphile-migrate"]

--- a/docs/docker/README.md
+++ b/docs/docker/README.md
@@ -1,0 +1,22 @@
+# Running Graphile Migrate from a container
+
+When working in a team it can be useful to package `graphile-migrate` and the
+postgres tooling into a docker file so that everyone has easy access to the
+same versions. This is also helpful if you're using Migrate as part of a larger
+non-nodejs based project.
+
+For these purposes we provide an [example docker file](./Dockerfile) in the
+`docs/docker` directory in the source tree.  This uses the latest released
+version of graphile-migrate from `npm` and packages it together with the
+necessary nodejs and postgres tools. You can build the docker file from the
+root of the repository using a command like
+
+```bash
+docker build -t graphile-migrate docs/docker \
+    --build-arg NODEJS_VERSION=14 --build-arg POSTGRES_VERSION=12
+```
+
+To conveniently run Graphile Migrate within the container you can then use the
+[`graphile-migrate` wrapper script](./graphile-migrate) which passes the
+standard Migrate environment variables through to the container.
+

--- a/docs/docker/README.md
+++ b/docs/docker/README.md
@@ -1,15 +1,15 @@
 # Running Graphile Migrate from a container
 
 When working in a team it can be useful to package `graphile-migrate` and the
-postgres tooling into a docker file so that everyone has easy access to the
+Postgres tooling into a Docker file so that everyone has easy access to the
 same versions. This is also helpful if you're using Migrate as part of a larger
-non-nodejs based project.
+non-Node based project.
 
-For these purposes we provide an [example docker file](./Dockerfile) in the
-`docs/docker` directory in the source tree.  This uses the latest released
-version of graphile-migrate from `npm` and packages it together with the
-necessary nodejs and postgres tools. You can build the docker file from the
-root of the repository using a command like
+For these purposes we provide an [example Dockerfile](./Dockerfile) in the
+`docs/docker` directory in the source tree. This uses the latest released
+version of `graphile-migrate` from `npm` and packages it together with the
+necessary Node and Postgres tools. You can build the Dockerfile from the
+root of the repository using a command like such as:
 
 ```bash
 docker build -t graphile-migrate docs/docker \
@@ -19,4 +19,3 @@ docker build -t graphile-migrate docs/docker \
 To conveniently run Graphile Migrate within the container you can then use the
 [`graphile-migrate` wrapper script](./graphile-migrate) which passes the
 standard Migrate environment variables through to the container.
-

--- a/docs/docker/graphile-migrate
+++ b/docs/docker/graphile-migrate
@@ -7,8 +7,8 @@
 # * --user     to allow the current user to own any committed migrations
 # * mount teamapp/dbconf for access to graphile-migrate working files
 
-# The following may be added if you run a postgres container on an internal
-# docker network which isn't accessible from the host where this script runs.
+# The following may be added if you run a Postgres container on an internal
+# Docker network which isn't accessible from the host where this script runs.
 if [[ ${DATABASE_DOCKER_NETWORK} != "" ]] ; then
     DOCKER_EXTRA_OPTS="${DOCKER_EXTRA_OPTS} --network ${DATABASE_DOCKER_NETWORK}"
 fi

--- a/docs/docker/graphile-migrate
+++ b/docs/docker/graphile-migrate
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# A wrapper for running graphile-migrate within a container
+
+# Use
+# * -ti --init to allow for CTRL-C to work with `graphile-migrate watch`
+# * --user     to allow the current user to own any committed migrations
+# * mount teamapp/dbconf for access to graphile-migrate working files
+
+# The following may be added if you run a postgres container on an internal
+# docker network which isn't accessible from the host where this script runs.
+if [[ ${DATABASE_DOCKER_NETWORK} != "" ]] ; then
+    DOCKER_EXTRA_OPTS="${DOCKER_EXTRA_OPTS} --network ${DATABASE_DOCKER_NETWORK}"
+fi
+
+docker run \
+    -ti --init \
+    --user "$(id -u):$(id -g)" \
+    --rm \
+    --volume "$PWD:/migrate" \
+    --env DATABASE_URL="${DATABASE_URL}" \
+    --env SHADOW_DATABASE_URL="${SHADOW_DATABASE_URL}" \
+    --env ROOT_DATABASE_URL="${ROOT_DATABASE_URL}" \
+    ${DOCKER_EXTRA_OPTS} \
+    graphile-migrate "$@"

--- a/docs/docker/graphile-migrate
+++ b/docs/docker/graphile-migrate
@@ -5,7 +5,7 @@
 # Use
 # * -ti --init to allow for CTRL-C to work with `graphile-migrate watch`
 # * --user     to allow the current user to own any committed migrations
-# * mount teamapp/dbconf for access to graphile-migrate working files
+# * Mount $PWD as /migrate for access to graphile-migrate working files
 
 # The following may be added if you run a Postgres container on an internal
 # Docker network which isn't accessible from the host where this script runs.


### PR DESCRIPTION
When working in a team it can be useful to package `graphile-migrate` and the postgres client tooling into a docker file so that everyone has easy access to the same versions. This is also helpful for my team as we're using Migrate as part of a larger non-nodejs based project and not everyone necessarily has node installed or necessarily has the right version.

For these purposes I've added an example docker file in `scripts/Dockerfile` which is derived from the one I set up for our internal use. This uses the latest released version of graphile-migrate from `npm` and packages it together with the necessary nodejs and postgres tools (versions of which can be chosen with build arguments).

At this stage, I've presented this tooling more as "an example of how you can package `graphle-migrate` for a team" rather than as an officially sanctioned way to do this (so arguably this could go in a "contrib" directory, but I just put it into scripts as that already exists). I'd say that integration testing this is probably a little complex, so given its status as an example I've just left that out for now.