### PR TITLE
feat: add root option to afterReset hooks of type command

### DIFF
--- a/README.md
+++ b/README.md
@@ -601,16 +601,20 @@ When the command is invoked it will have access to the following envvars:
 
 - `GM_DBURL` - the relevant database URL (e.g. the one that was just
   reset/migrated)
-- `GM_DBNAME` - the database name in `GM_DBURL`; you might use this if you need
-  to use separate superuser credentials to install extensions against the
-  database
-- `GM_DBUSER` - the database user in `GM_DBURL`
+- `GM_DBNAME` - the database name in `GM_DBURL`
+- `GM_DBUSER` - the database user in `GM_DBURL` if `root` is `false`.
 - `GM_SHADOW` - set to `1` if we're dealing with the shadow DB, unset otherwise
 
 **IMPORTANT NOTE** the `DATABASE_URL` envvar will be set to the nonsense value
 `postgres://PLEASE:USE@GM_DBURL/INSTEAD` to avoid ambiguity - you almost
 certainly mean to use `GM_DBURL` in your scripts since they will want to change
 whichever database was just reset/migrated/etc (which could be the shadow DB).
+
+The `root` property applies to `command` actions with the similar effects as
+`sql` actions (see above). When `true`, the command will be run with GM_DBURL
+envvar set using the superuser role (i.e. the one defined in
+`rootConnectionString`) but with the database name from `connectionString`. When
+`root` is true, `GM_DBUSER` is not set.
 
 ## Collaboration
 

--- a/__tests__/actions.test.ts
+++ b/__tests__/actions.test.ts
@@ -116,7 +116,7 @@ it("runs command afterReset action with correct env vars when root", async () =>
   const connectionStringParts = parse(TEST_DATABASE_URL);
   const rootConnectionStringParts = parse(TEST_ROOT_DATABASE_URL);
   expect(rootConnectionStringParts.database).not.toBe(
-    connectionStringParts.database
+    connectionStringParts.database,
   );
   const execUrlParts = parse(mockedExec.mock.calls[0][1].env.GM_DBURL);
   expect(execUrlParts.host).toBe(rootConnectionStringParts.host);

--- a/__tests__/actions.test.ts
+++ b/__tests__/actions.test.ts
@@ -115,7 +115,9 @@ it("runs command afterReset action with correct env vars when root", async () =>
   expect(mockedExec.mock.calls[0][1].env.GM_DBUSER).toBe(undefined);
   const connectionStringParts = parse(TEST_DATABASE_URL);
   const rootConnectionStringParts = parse(TEST_ROOT_DATABASE_URL);
-  expect(rootConnectionStringParts.database).not.toBe(connectionStringParts.database);
+  expect(rootConnectionStringParts.database).not.toBe(
+    connectionStringParts.database
+  );
   const execUrlParts = parse(mockedExec.mock.calls[0][1].env.GM_DBURL);
   expect(execUrlParts.host).toBe(rootConnectionStringParts.host);
   expect(execUrlParts.port).toBe(rootConnectionStringParts.port);

--- a/__tests__/actions.test.ts
+++ b/__tests__/actions.test.ts
@@ -115,6 +115,7 @@ it("runs command afterReset action with correct env vars when root", async () =>
   expect(mockedExec.mock.calls[0][1].env.GM_DBUSER).toBe(undefined);
   const connectionStringParts = parse(TEST_DATABASE_URL);
   const rootConnectionStringParts = parse(TEST_ROOT_DATABASE_URL);
+  expect(rootConnectionStringParts.database).not.toBe(connectionStringParts.database);
   const execUrlParts = parse(mockedExec.mock.calls[0][1].env.GM_DBURL);
   expect(execUrlParts.host).toBe(rootConnectionStringParts.host);
   expect(execUrlParts.port).toBe(rootConnectionStringParts.port);

--- a/__tests__/actions.test.ts
+++ b/__tests__/actions.test.ts
@@ -9,8 +9,13 @@ import * as mockFs from "mock-fs";
 
 import { executeActions } from "../src/actions";
 import { _migrate } from "../src/commands/migrate";
+import { withClient } from "../src/pg";
 import { parseSettings } from "../src/settings";
-import { mockPgClient, TEST_DATABASE_URL } from "./helpers";
+import {
+  mockPgClient,
+  TEST_DATABASE_URL,
+  TEST_ROOT_DATABASE_URL,
+} from "./helpers";
 
 beforeAll(() => {
   // eslint-disable-next-line no-console
@@ -72,6 +77,42 @@ it("runs command actions", async () => {
   expect(mockedExec.mock.calls[0][1].env.PATH).toBe(process.env.PATH);
   expect(mockedExec.mock.calls[0][1].env.GM_SHADOW).toBe(undefined);
   expect(typeof mockedExec.mock.calls[0][1].env.GM_DBURL).toBe("string");
+});
+
+it("runs sql afterReset action with correct connection string when root", async () => {
+  mockFs({
+    "migrations/sqlfile1.sql": `[CONTENT:migrations/sqlfile1.sql]`,
+  });
+  const parsedSettings = await parseSettings({
+    connectionString: TEST_DATABASE_URL,
+    afterReset: [{ _: "sql", file: "sqlfile1.sql", root: true }],
+  });
+  const mockedWithClient: jest.Mock<typeof withClient> = withClient as any;
+  mockedWithClient.mockClear();
+  await executeActions(parsedSettings, false, parsedSettings.afterReset);
+  expect(mockedWithClient).toHaveBeenCalledTimes(1);
+  expect(mockedWithClient.mock.calls[0][0]).toBe("graphile_migrate_test");
+});
+
+it("runs command afterReset action with correct env vars when root", async () => {
+  const parsedSettings = await parseSettings({
+    connectionString: TEST_DATABASE_URL,
+    rootConnectionString: TEST_ROOT_DATABASE_URL,
+    afterReset: [
+      { _: "command", command: "touch testCommandAction", root: true },
+    ],
+  });
+  const mockedExec: jest.Mock<typeof exec> = exec as any;
+  mockedExec.mockClear();
+  mockedExec.mockImplementationOnce((_cmd, _options, callback) =>
+    callback(null, { stdout: "", stderr: "" }),
+  );
+
+  await executeActions(parsedSettings, false, parsedSettings.afterReset);
+  expect(mockedExec.mock.calls[0][1].env.GM_DBUSER).toBe(undefined);
+  expect(mockedExec.mock.calls[0][1].env.GM_DBURL).toBe(
+    "graphile_migrate_test",
+  );
 });
 
 it("run normal and non-shadow actions in non-shadow mode", async () => {

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -27,7 +27,7 @@ if (!/^[a-zA-Z0-9_-]+$/.test(TEST_DATABASE_NAME)) {
   throw new Error("Invalid database name " + TEST_DATABASE_NAME);
 }
 
-const TEST_ROOT_DATABASE_URL: string =
+export const TEST_ROOT_DATABASE_URL: string =
   process.env.TEST_ROOT_DATABASE_URL || "postgres";
 
 export const settings: Settings = {

--- a/__tests__/settings.test.ts
+++ b/__tests__/settings.test.ts
@@ -180,7 +180,7 @@ describe("makeRootDatabaseConnectionString", () => {
     );
   });
 
-  it("handles a standalone DB namee", async () => {
+  it("handles a standalone DB name", async () => {
     mockFs.restore();
     const parsedSettings = await parseSettings({
       connectionString: exampleConnectionString,

--- a/__tests__/settings.test.ts
+++ b/__tests__/settings.test.ts
@@ -180,7 +180,7 @@ describe("makeRootDatabaseConnectionString", () => {
     );
   });
 
-  it("handles a standalone DB name", async () => {
+  it("handles a standalone DB name that is not a valid URL", async () => {
     mockFs.restore();
     const parsedSettings = await parseSettings({
       connectionString: exampleConnectionString,

--- a/__tests__/settings.test.ts
+++ b/__tests__/settings.test.ts
@@ -179,6 +179,19 @@ describe("makeRootDatabaseConnectionString", () => {
       "postgres://root:pass@localhost:5432/modified?ssl=true&sslrootcert=./__tests__/data/amazon-rds-ca-cert.pem",
     );
   });
+
+  it("handles a standalone DB namee", async () => {
+    mockFs.restore();
+    const parsedSettings = await parseSettings({
+      connectionString: exampleConnectionString,
+      rootConnectionString: "just_a_db",
+    });
+    const connectionString = makeRootDatabaseConnectionString(
+      parsedSettings,
+      "modified",
+    );
+    expect(connectionString).toBe("modified");
+  });
 });
 
 describe("actions", () => {

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -101,7 +101,12 @@ export async function executeActions(
           },
           {
             GM_DBNAME: databaseName,
-            GM_DBUSER: actionSpec.root ? undefined : databaseUser,
+            // When `root: true`, GM_DBUSER may be perceived as ambiguous, so we must not set it.
+            ...(actionSpec.root
+              ? null
+              : {
+                  GM_DBUSER: databaseUser,
+                }),
             GM_DBURL: hookConnectionString,
             ...(shadow
               ? {

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -18,13 +18,6 @@ import {
 interface ActionSpecBase {
   _: string;
   shadow?: boolean;
-}
-
-export const DO_NOT_USE_DATABASE_URL = "postgres://PLEASE:USE@GM_DBURL/INSTEAD";
-
-export interface SqlActionSpec extends ActionSpecBase {
-  _: "sql";
-  file: string;
 
   /**
    * USE THIS WITH CARE! Currently only supported by the afterReset hook, all
@@ -33,6 +26,13 @@ export interface SqlActionSpec extends ActionSpecBase {
    * connectionString), useful for creating extensions.
    */
   root?: boolean;
+}
+
+export const DO_NOT_USE_DATABASE_URL = "postgres://PLEASE:USE@GM_DBURL/INSTEAD";
+
+export interface SqlActionSpec extends ActionSpecBase {
+  _: "sql";
+  file: string;
 }
 
 export interface CommandActionSpec extends ActionSpecBase {
@@ -70,14 +70,14 @@ export async function executeActions(
     if (actionSpec.shadow !== undefined && actionSpec.shadow !== shadow) {
       continue;
     }
+    const hookConnectionString = actionSpec.root
+      ? makeRootDatabaseConnectionString(parsedSettings, databaseName)
+      : connectionString;
     if (actionSpec._ === "sql") {
       const body = await fsp.readFile(
         `${parsedSettings.migrationsFolder}/${actionSpec.file}`,
         "utf8",
       );
-      const hookConnectionString = actionSpec.root
-        ? makeRootDatabaseConnectionString(parsedSettings, databaseName)
-        : connectionString;
       await withClient(
         hookConnectionString,
         parsedSettings,
@@ -101,8 +101,8 @@ export async function executeActions(
           },
           {
             GM_DBNAME: databaseName,
-            GM_DBUSER: databaseUser,
-            GM_DBURL: connectionString,
+            GM_DBUSER: actionSpec.root ? undefined : databaseUser,
+            GM_DBURL: hookConnectionString,
             ...(shadow
               ? {
                   GM_SHADOW: "1",

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -417,7 +417,7 @@ export function makeRootDatabaseConnectionString(
       return `socket:${parsed.pathname}?${query}`;
     }
   } else {
-    parsed.pathname = `/${databaseName}`;
+    parsed.pathname = databaseName;
     return formatURL(parsed);
   }
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -407,6 +407,7 @@ export function makeRootDatabaseConnectionString(
     );
   }
   const parsed = parseURL(rootConnectionString, true);
+  const isJustADatabaseName = !parsed.protocol;
   if (parsed.protocol === "socket:") {
     parsed.query.db = databaseName;
     const query = querystring.stringify(parsed.query);
@@ -416,8 +417,10 @@ export function makeRootDatabaseConnectionString(
     } else {
       return `socket:${parsed.pathname}?${query}`;
     }
+  } else if (isJustADatabaseName) {
+    return databaseName;
   } else {
-    parsed.pathname = databaseName;
+    parsed.pathname = `/${databaseName}`;
     return formatURL(parsed);
   }
 }


### PR DESCRIPTION
## Description

Fix for [issue 132](https://github.com/graphile/migrate/issues/132). afterReset actions of type command now respect the `root` property in the action spec

## Performance impact

I can't imagine a performance cost to this

## Security impact

None that I'm aware of

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [x] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

I wasn't able to get my unit tests to run locally. Happy to try to write a test for this if you have any advice on what I'm missing? This was the behavior when I checked out the commit before mine so none of my changes are involved here.

```
yarn test
yarn run v1.22.10
$ yarn lint && depcheck --ignores @types/jest,eslint_d,tslib && yarn run test:only --ci
$ yarn prettier:check && eslint --ext .js,.jsx,.ts,.tsx,.graphql .
$ prettier --ignore-path .eslintignore --check '**/*.{js,jsx,ts,tsx,graphql,md,json}'
Checking formatting...
docs/docker/README.md
docs/idempotent-examples.md
README.md
Code style issues found in the above file(s). Forgot to run Prettier?
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

Also, I don't see a RELEASE_NOTES.md, so I made no additions there.