### PR TITLE
docs: update list of supported Node versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -781,8 +781,9 @@ diverse) projects:
 
 We only support LTS versions of Node.js; the currently supported versions are:
 
-- Node v12.x
 - Node v14.x
+- Node v16.x
+- Node v18.x
 
 Other versions of Node may work, but are not officially supported.
 


### PR DESCRIPTION
Technically Node 12 and Node 10 both still work; but they're not _officially_ supported any more because they've left LTS.