### PR TITLE
fix: log stdout/stderr on action failures

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,15 @@ volumes:
     driver: local
 ```
 
+### Creating the database
+
+You'll then need to connect to the database and issue the following commands:
+
+```sql
+create role gmtestuser with login password 'gmtestpass';
+create database graphile_migrate_test owner gmtestuser;
+```
+
 ## ASK FIRST!
 
 There's nothing worse than having your PR with 3 days of work in it rejected

--- a/__tests__/actions-live.test.ts
+++ b/__tests__/actions-live.test.ts
@@ -1,0 +1,95 @@
+import "./helpers"; // Has side-effects; must come first
+
+import { Logger, LogLevel, LogMeta } from "@graphile/logger";
+import * as mockFs from "mock-fs";
+
+import { executeActions } from "../src/actions";
+import { _migrate } from "../src/commands/migrate";
+import { parseSettings } from "../src/settings";
+import { mockPgClient, TEST_DATABASE_URL } from "./helpers";
+
+beforeAll(() => {
+  // eslint-disable-next-line no-console
+  console.log("[mock-fs callsites hack]"); // Without this, jest fails due to 'callsites'
+  mockFs({});
+});
+
+afterAll(() => {
+  mockFs.restore();
+});
+
+it("logs output from command actions on success", async () => {
+  const logs: Array<{
+    scope: any;
+    level: LogLevel;
+    message: string;
+    meta?: LogMeta;
+  }> = [];
+  const logger = new Logger(scope => (level, message, meta) => {
+    logs.push({ scope, level, message, meta });
+  });
+  const parsedSettings = await parseSettings({
+    connectionString: TEST_DATABASE_URL,
+    afterAllMigrations: [
+      { _: "command", command: "echo 'success' && echo 'err' >&2" },
+    ],
+    logger,
+  });
+  mockPgClient.query.mockClear();
+  await executeActions(
+    parsedSettings,
+    false,
+    parsedSettings.afterAllMigrations,
+  );
+  expect(mockPgClient.query).toHaveBeenCalledTimes(0);
+  expect(logs).toHaveLength(2);
+  expect(logs[0]).toMatchObject({
+    level: "info",
+    message: "success\n",
+  });
+  expect(logs[1]).toMatchObject({
+    level: "error",
+    message: "err\n",
+  });
+});
+
+it("logs output from command actions on failure", async () => {
+  const logs: Array<{
+    scope: any;
+    level: LogLevel;
+    message: string;
+    meta?: LogMeta;
+  }> = [];
+  const logger = new Logger(scope => (level, message, meta) => {
+    logs.push({ scope, level, message, meta });
+  });
+  const parsedSettings = await parseSettings({
+    connectionString: TEST_DATABASE_URL,
+    afterAllMigrations: [
+      { _: "command", command: "echo 'success' && echo 'err' >&2 && false" },
+    ],
+    logger,
+  });
+  mockPgClient.query.mockClear();
+  let err;
+  try {
+    await executeActions(
+      parsedSettings,
+      false,
+      parsedSettings.afterAllMigrations,
+    );
+  } catch (e) {
+    err = e;
+  }
+  expect(err).toBeTruthy();
+  expect(mockPgClient.query).toHaveBeenCalledTimes(0);
+  expect(logs).toHaveLength(2);
+  expect(logs[0]).toMatchObject({
+    level: "info",
+    message: "success\n",
+  });
+  expect(logs[1]).toMatchObject({
+    level: "error",
+    message: "err\n",
+  });
+});

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -93,7 +93,7 @@ export async function executeActions(
       );
     } else if (actionSpec._ === "command") {
       // Run the command
-      const { stdout, stderr } = await exec(actionSpec.command, {
+      const promise = exec(actionSpec.command, {
         env: mergeWithoutClobbering(
           {
             ...process.env,
@@ -120,11 +120,23 @@ export async function executeActions(
         // 50MB of log data should be enough for any reasonable migration... right?
         maxBuffer: 50 * 1024 * 1024,
       });
-      if (stdout) {
-        parsedSettings.logger.info(stdout);
-      }
-      if (stderr) {
-        parsedSettings.logger.error(stderr);
+      try {
+        const { stdout, stderr } = await promise;
+        if (stdout) {
+          parsedSettings.logger.info(stdout);
+        }
+        if (stderr) {
+          parsedSettings.logger.error(stderr);
+        }
+      } catch (e) {
+        const { stdout, stderr } = e;
+        if (stdout) {
+          parsedSettings.logger.info(stdout);
+        }
+        if (stderr) {
+          parsedSettings.logger.error(stderr);
+        }
+        throw e;
       }
     }
   }


### PR DESCRIPTION
Fixes #167
Fixes #152

## Description

We weren't previously outputting stdout/stderr of command actions when an error occurred. This fixes that, and also adds tests.

## Performance impact

Virtually none.

## Security impact

None.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [ ] ~~I have detailed the new feature in the relevant documentation.~~
- [ ] ~~I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).~~
- [ ] ~~If this is a breaking change I've explained why.~~
