### PR TITLE
Fix chalk import

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,4 +1,4 @@
-import * as chalk from "chalk";
+import chalk from "chalk";
 import { QueryResultRow } from "pg";
 
 import indent from "./indent";


### PR DESCRIPTION
I upgraded to `2.0.0-rc.0`. And ran into some errors when migrations contained an error:

```sh
> postgraphile@1.0.0 watch /Users/dyl/dev/CAI/atrace-backend/packages/db-schema
> graphile-migrate watch

graphile-migrate: Up to date — no committed migrations to run
[2024-01-23T11:04:10.861Z]: Running current.sql
Error occurred whilst processing migration: Cannot read properties of undefined (reading 'bold')
```

I had a quick look and this seems to be the solution. 