### PR TITLE
fix: Use .default to access CJS module for dynamic imports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ env:
   TEST_ROOT_DATABASE_URL: postgres://postgres:postgres@127.0.0.1:5432/postgres
   TEST_DATABASE_URL: postgres://someone:something@127.0.0.1:5432/graphile_migrate_test
   PGVERSION: 10
+  NODE_OPTIONS: "--experimental-vm-modules"
 
 jobs:
   test:

--- a/__tests__/settings.test.ts
+++ b/__tests__/settings.test.ts
@@ -349,7 +349,10 @@ describe("gmrc path", () => {
 });
 
 describe("gmrc from JS", () => {
-  it("supports .gmrc.js", async () => {
+  const nodeMajor = parseInt(process.versions.node.split(".")[0], 10);
+  // Only test these on Node20+
+  const node20PlusIt = nodeMajor >= 20 ? it : it.skip.bind(it);
+  node20PlusIt("supports .gmrc.js", async () => {
     mockFs.restore();
     // The warmups force all the parts of Node import to be exercised before we
     // try and import something from our mocked filesystem.
@@ -369,7 +372,7 @@ module.exports = {
     mockFs.restore();
   });
 
-  it("supports .gmrc.cjs", async () => {
+  node20PlusIt("supports .gmrc.cjs", async () => {
     mockFs.restore();
     // The warmups force all the parts of Node import to be exercised before we
     // try and import something from our mocked filesystem.

--- a/__tests__/settings.test.ts
+++ b/__tests__/settings.test.ts
@@ -3,7 +3,12 @@ import "./helpers"; // Side effects - must come first
 import mockFs from "mock-fs";
 import * as path from "path";
 
-import { DEFAULT_GMRC_PATH, getSettings } from "../src/commands/_common";
+import {
+  DEFAULT_GMRC_COMMONJS_PATH,
+  DEFAULT_GMRC_PATH,
+  DEFAULT_GMRCJS_PATH,
+  getSettings,
+} from "../src/commands/_common";
 import {
   makeRootDatabaseConnectionString,
   ParsedSettings,
@@ -338,6 +343,48 @@ describe("gmrc path", () => {
     const settings = await getSettings({ configFile: ".other-gmrc" });
     expect(settings.connectionString).toEqual(
       "postgres://appuser:apppassword@host:5432/otherdb",
+    );
+    mockFs.restore();
+  });
+});
+
+describe("gmrc from JS", () => {
+  it("supports .gmrc.js", async () => {
+    mockFs.restore();
+    // The warmups force all the parts of Node import to be exercised before we
+    // try and import something from our mocked filesystem.
+    // @ts-ignore
+    await Promise.all([import("./warmup.js"), import("./warmup.cjs")]);
+
+    mockFs({
+      [DEFAULT_GMRCJS_PATH]: /* JavaScript */ `\
+module.exports = {
+  connectionString: "postgres://appuser:apppassword@host:5432/gmrcjs_test",
+};`,
+    });
+    const settings = await getSettings();
+    expect(settings.connectionString).toEqual(
+      "postgres://appuser:apppassword@host:5432/gmrcjs_test",
+    );
+    mockFs.restore();
+  });
+
+  it("supports .gmrc.cjs", async () => {
+    mockFs.restore();
+    // The warmups force all the parts of Node import to be exercised before we
+    // try and import something from our mocked filesystem.
+    // @ts-ignore
+    await Promise.all([import("./warmup.js"), import("./warmup.cjs")]);
+
+    mockFs({
+      [DEFAULT_GMRC_COMMONJS_PATH]: /* JavaScript */ `\
+module.exports = {
+  connectionString: "postgres://appuser:apppassword@host:5432/gmrc_commonjs_test",
+};`,
+    });
+    const settings = await getSettings();
+    expect(settings.connectionString).toEqual(
+      "postgres://appuser:apppassword@host:5432/gmrc_commonjs_test",
     );
     mockFs.restore();
   });

--- a/__tests__/warmup.cjs
+++ b/__tests__/warmup.cjs
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/__tests__/warmup.js
+++ b/__tests__/warmup.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "prepack": "npm run tsc && chmod +x dist/cli.js",
     "clean": "rm -Rf dist",
     "test": "yarn lint && yarn run lint:deps && FORCE_COLOR=1 yarn run test:only --ci",
-    "test:only": "jest -i",
+    "test:only": "NODE_OPTIONS=\"--experimental-vm-modules\" jest -i",
     "version": "yarn prepack && ./scripts/update-docs.js && node ./scripts/version.mjs && git add README.md src/version.ts",
     "watch": "mkdir -p dist && touch dist/cli.js && chmod +x dist/cli.js && npm run tsc --watch"
   },

--- a/src/commands/_common.ts
+++ b/src/commands/_common.ts
@@ -77,7 +77,10 @@ export async function getSettings(options: Options = {}): Promise<Settings> {
     const relativePath = pathToFileURL(resolve(process.cwd(), path)).href;
 
     try {
-      return (await import(relativePath)) as Settings;
+      const module = (await import(relativePath)) as {
+        default: Settings;
+      };
+      return module.default;
     } catch (e) {
       throw new Error(
         `Failed to import '${relativePath}'; error:\n    ${

--- a/src/commands/_common.ts
+++ b/src/commands/_common.ts
@@ -77,10 +77,8 @@ export async function getSettings(options: Options = {}): Promise<Settings> {
     const relativePath = pathToFileURL(resolve(process.cwd(), path)).href;
 
     try {
-      const module = (await import(relativePath)) as {
-        default: Settings;
-      };
-      return module.default;
+      const module = await import(relativePath);
+      return module.default as Settings;
     } catch (e) {
       throw new Error(
         `Failed to import '${relativePath}'; error:\n    ${

--- a/src/commands/_common.ts
+++ b/src/commands/_common.ts
@@ -77,8 +77,8 @@ export async function getSettings(options: Options = {}): Promise<Settings> {
     const relativePath = pathToFileURL(resolve(process.cwd(), path)).href;
 
     try {
-      const module = await import(relativePath);
-      return module.default as Settings;
+      const module = (await import(relativePath)) as Record<string, unknown>;
+      return (module.default ?? module) as Settings;
     } catch (e) {
       throw new Error(
         `Failed to import '${relativePath}'; error:\n    ${


### PR DESCRIPTION
## Description

Small fix to address a regression introduced as part of #198, when we moved from require -> import.

When dynamic-importing CJS/ESM modules, `export default { ... }` and `module.exports = ...` is placed under a `default` key (as opposed to `require` where the CJS module was returned as the top level object. This meant using a `.cjs` config would fail when parsing the settings with:

```
Error: Errors occurred during settings validation:
- Setting 'connectionString': Expected a string, or for DATABASE_URL envvar to be set
- Setting 'databaseOwner': Expected a string or for user or database name to be specified in connectionString
- Setting 'shadowConnectionString': Expected `shadowConnectionString` to be a string, or for SHADOW_DATABASE_URL to be set
- The following config settings were not understood: 'default'
- Could not determine the shadow database name, please ensure shadowConnectionString includes the database name.
```

I explored adding regression tests to ensure this didn't happen again but it looks like jest needs some extra configuration to support dynamic `import()`s so I've opted for the fingers-crossed🤞 approach that we won't accidentally break this again instead. If you reckon there's a clear approach to support this in jest, happy to add as part of the PR.

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
