### PR TITLE
allow spaces / tabs before --!include fixtures

### DIFF
--- a/src/migration.ts
+++ b/src/migration.ts
@@ -132,7 +132,7 @@ export async function compileIncludes(
   content: string,
   processedFiles: ReadonlySet<string>,
 ): Promise<string> {
-  const regex = /^--![ \t]*include[ \t]+(.*\.sql)[ \t]*$/gm;
+  const regex = /^[ \t]*--![ \t]*include[ \t]+(.*\.sql)[ \t]*$/gm;
 
   // Find all includes in this `content`
   const matches = [...content.matchAll(regex)];


### PR DESCRIPTION
## Description

The new fixture feature is really cool, but I hit an issue where my code was not being included and I was totally clueless!

Actually, the only issue was that I had a space before `--!include`... 

That's why I suggest to relax the regex so it allows spaces/tabs before the pattern.

To be honest I would even relax it more so it gets triggered even when you forget the `.sql` extension so it raises an error instead of silently ignoring it as it does today.

## Performance impact

none

## Security impact

none

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [x] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
