### PR TITLE
Rename `appuser` -> `dbuser` and link to discussion in issue #215

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ createdb myapp --owner=dbowner
 createdb myapp_shadow --owner=dbowner
 ```
 
-> For an in depth-discussion on the different users and roles typically
-> involved in database and migration management, please see issue
+> For an in depth-discussion on the different users and roles typically involved
+> in database and migration management, please see issue
 > [#215](https://github.com/graphile/migrate/issues/215).
 
 Export your database URL, shadow database URL, and a "root" database URL which

--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ createdb myapp --owner=dbowner
 createdb myapp_shadow --owner=dbowner
 ```
 
+> For an in depth-discussion on the different users and roles typically
+> involved in database and migration management, please see issue
+> [#215](https://github.com/graphile/migrate/issues/215).
+
 Export your database URL, shadow database URL, and a "root" database URL which
 should be a superuser account connection to any **other** database (most
 PostgreSQL servers have a default database called `postgres` which is a good

--- a/README.md
+++ b/README.md
@@ -108,9 +108,9 @@ unaffected by the iteration you've been applying to your development database
 Create your database role (if desired), database and shadow database:
 
 ```bash
-createuser --pwprompt appuser
-createdb myapp --owner=appuser
-createdb myapp_shadow --owner=appuser
+createuser --pwprompt dbowner
+createdb myapp --owner=dbowner
+createdb myapp_shadow --owner=dbowner
 ```
 
 Export your database URL, shadow database URL, and a "root" database URL which
@@ -119,8 +119,8 @@ PostgreSQL servers have a default database called `postgres` which is a good
 choice for this).
 
 ```bash
-export DATABASE_URL="postgres://appuser:password@localhost/myapp"
-export SHADOW_DATABASE_URL="postgres://appuser:password@localhost/myapp_shadow"
+export DATABASE_URL="postgres://dbowner:password@localhost/myapp"
+export SHADOW_DATABASE_URL="postgres://dbowner:password@localhost/myapp_shadow"
 
 export ROOT_DATABASE_URL="postgres://postgres:postgres@localhost/postgres"
 ```

--- a/__tests__/settings.test.ts
+++ b/__tests__/settings.test.ts
@@ -320,12 +320,12 @@ describe("gmrc path", () => {
     mockFs.restore();
     mockFs({
       [DEFAULT_GMRC_PATH]: `
-        { "connectionString": "postgres://appuser:apppassword@host:5432/defaultdb" }
+        { "connectionString": "postgres://dbowner:password@host:5432/defaultdb" }
       `,
     });
     const settings = await getSettings();
     expect(settings.connectionString).toEqual(
-      "postgres://appuser:apppassword@host:5432/defaultdb",
+      "postgres://dbowner:password@host:5432/defaultdb",
     );
     mockFs.restore();
   });
@@ -334,15 +334,15 @@ describe("gmrc path", () => {
     mockFs.restore();
     mockFs({
       [DEFAULT_GMRC_PATH]: `
-        { "connectionString": "postgres://appuser:apppassword@host:5432/defaultdb" }
+        { "connectionString": "postgres://dbowner:password@host:5432/defaultdb" }
       `,
       ".other-gmrc": `
-        { "connectionString": "postgres://appuser:apppassword@host:5432/otherdb" }
+        { "connectionString": "postgres://dbowner:password@host:5432/otherdb" }
       `,
     });
     const settings = await getSettings({ configFile: ".other-gmrc" });
     expect(settings.connectionString).toEqual(
-      "postgres://appuser:apppassword@host:5432/otherdb",
+      "postgres://dbowner:password@host:5432/otherdb",
     );
     mockFs.restore();
   });
@@ -362,12 +362,12 @@ describe("gmrc from JS", () => {
     mockFs({
       [DEFAULT_GMRCJS_PATH]: /* JavaScript */ `\
 module.exports = {
-  connectionString: "postgres://appuser:apppassword@host:5432/gmrcjs_test",
+  connectionString: "postgres://dbowner:password@host:5432/gmrcjs_test",
 };`,
     });
     const settings = await getSettings();
     expect(settings.connectionString).toEqual(
-      "postgres://appuser:apppassword@host:5432/gmrcjs_test",
+      "postgres://dbowner:password@host:5432/gmrcjs_test",
     );
     mockFs.restore();
   });
@@ -382,12 +382,12 @@ module.exports = {
     mockFs({
       [DEFAULT_GMRC_COMMONJS_PATH]: /* JavaScript */ `\
 module.exports = {
-  connectionString: "postgres://appuser:apppassword@host:5432/gmrc_commonjs_test",
+  connectionString: "postgres://dbowner:password@host:5432/gmrc_commonjs_test",
 };`,
     });
     const settings = await getSettings();
     expect(settings.connectionString).toEqual(
-      "postgres://appuser:apppassword@host:5432/gmrc_commonjs_test",
+      "postgres://dbowner:password@host:5432/gmrc_commonjs_test",
     );
     mockFs.restore();
   });

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -46,7 +46,7 @@ export async function init(options: InitArgv = {}): Promise<void> {
    *
    * RECOMMENDATION: use \`DATABASE_URL\` envvar instead.
    */
-  // "connectionString": "postgres://appuser:apppassword@host:5432/appdb",
+  // "connectionString": "postgres://dbowner:password@host:5432/appdb",
 
   /*
    * shadowConnectionString: like connectionString, but this is used for the
@@ -54,7 +54,7 @@ export async function init(options: InitArgv = {}): Promise<void> {
    *
    * RECOMMENDATION: use \`SHADOW_DATABASE_URL\` envvar instead.
    */
-  // "shadowConnectionString": "postgres://appuser:apppassword@host:5432/appdb_shadow",
+  // "shadowConnectionString": "postgres://dbowner:password@host:5432/appdb_shadow",
 
   /*
    * rootConnectionString: like connectionString, but this is used for


### PR DESCRIPTION
## Description

Rename `appuser` to `dbuser` to reduce confusion and link to the discussion in #215 when discussing the creation of users and roles.

resolves #215 

## Performance impact

N/A

## Security impact

N/A - Hopefully reduces confusion and makes it easier for users to improve their own security

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [x] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
