### PR TITLE
feat: Allow configurable graphile migration schema name

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,8 @@ options are available:
   migrations isn't granted schema creation privileges. If you set this to
   `false`, you must be sure to migrate the `graphile_migrate` database schema
   any time you update the `graphile-migrate` module.
+- `graphileMigrateSchema` (defaults to `graphile_migrate`) - sets the schema name
+  for the migration tables.
 - `blankMigrationContent` ─ what should be written to the current migration
   after commit. NOTE: this should only contain comments such that the current
   commit is "empty-ish" on creation.

--- a/__tests__/__snapshots__/settings.test.ts.snap
+++ b/__tests__/__snapshots__/settings.test.ts.snap
@@ -30,6 +30,7 @@ exports[`actions is backwards-compatible with untagged command specs 1`] = `
   "connectionString": "postgres://localhost:5432/dbname?ssl=true",
   "databaseName": "dbname",
   "databaseOwner": "dbname",
+  "graphileMigrateSchema": "graphile_migrate",
   "logger": Logger {
     "_logFactory": [Function],
     "_scope": {},
@@ -71,6 +72,7 @@ exports[`actions parses SQL actions 1`] = `
   "connectionString": "postgres://localhost:5432/dbname?ssl=true",
   "databaseName": "dbname",
   "databaseOwner": "dbname",
+  "graphileMigrateSchema": "graphile_migrate",
   "logger": Logger {
     "_logFactory": [Function],
     "_scope": {},
@@ -107,6 +109,7 @@ exports[`actions parses command actions 1`] = `
   "connectionString": "postgres://localhost:5432/dbname?ssl=true",
   "databaseName": "dbname",
   "databaseOwner": "dbname",
+  "graphileMigrateSchema": "graphile_migrate",
   "logger": Logger {
     "_logFactory": [Function],
     "_scope": {},
@@ -151,6 +154,7 @@ exports[`actions parses mixed actions 1`] = `
   "connectionString": "postgres://localhost:5432/dbname?ssl=true",
   "databaseName": "dbname",
   "databaseOwner": "dbname",
+  "graphileMigrateSchema": "graphile_migrate",
   "logger": Logger {
     "_logFactory": [Function],
     "_scope": {},
@@ -192,6 +196,7 @@ exports[`actions parses string values into SQL actions 1`] = `
   "connectionString": "postgres://localhost:5432/dbname?ssl=true",
   "databaseName": "dbname",
   "databaseOwner": "dbname",
+  "graphileMigrateSchema": "graphile_migrate",
   "logger": Logger {
     "_logFactory": [Function],
     "_scope": {},

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -172,10 +172,16 @@ export async function init(options: InitArgv = {}): Promise<void> {
 
   /*
    * manageGraphileMigrateSchema: if you set this false, you must be sure to
-   * keep the graphile_migrate schema up to date yourself. We recommend you
+   * keep the migration schema up to date yourself. We recommend you
    * leave it at its default.
    */
   // "manageGraphileMigrateSchema": true,
+
+  /*
+   * graphileMigrateSchema: the schema name to use for reading/storing migrations,
+   * defaults to "graphile_migrate". We recommend you leave it at its default.
+   */
+  // "graphileMigrateSchema": "graphile_migrate",
 
   /*
    * migrationsFolder: path to the folder in which to store your migrations.

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,4 +1,4 @@
-/** Represents the graphile_migrate.current type in the DB */
+/** Represents the "current" type in the DB */
 export interface DbCurrent {
   filename: string;
   content: string;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -68,6 +68,7 @@ export interface Settings {
   shadowConnectionString?: string;
   rootConnectionString?: string;
   databaseOwner?: string;
+  graphileMigrateSchema?: string;
   migrationsFolder?: string;
   manageGraphileMigrateSchema?: boolean;
   pgSettings?: {
@@ -92,6 +93,7 @@ export interface ParsedSettings extends Settings {
   rootConnectionString: string;
   databaseOwner: string;
   databaseName: string;
+  graphileMigrateSchema: string;
   shadowDatabaseName?: string;
   migrationsFolder: string;
   beforeReset: ActionSpec[];
@@ -317,6 +319,19 @@ export async function parseSettings(
     },
   );
 
+  const graphileMigrateSchema = await check("graphileMigrateSchema", (graphileMigrateSchema = 'graphile_migrate') => {
+    if (typeof graphileMigrateSchema !== "string") {
+      throw new Error(
+        "Expected a string for graphile migrate schema name",
+      );
+    } else if (!/^[a-zA-Z_][a-zA-Z0-9_]{0,62}$/.test(graphileMigrateSchema)) {
+      throw new Error(
+        "Invalid format for graphile migrate schema name",
+      );
+    }
+    return graphileMigrateSchema;
+  },)
+
   /******/
 
   const uncheckedKeys = keysToCheck
@@ -379,6 +394,7 @@ export async function parseSettings(
     afterCurrent,
     rootConnectionString,
     connectionString,
+    graphileMigrateSchema,
     manageGraphileMigrateSchema,
     databaseOwner,
     migrationsFolder,


### PR DESCRIPTION
## Description

This PR adds a new configuration property called `graphileMigrateSchema`, which allows users to override the default schema value (`graphile_migrate`). This provides flexibility in defining where migration tables should be stored. 

### Motivation
The default behavior of Graphile Migrate places migration tables in the `graphile_migrate` schema. However, some users may prefer to manage migrations in a different schema for organizational or security reasons. This feature introduces a configurable option to support that use case.

## Performance impact

Unknown. No significant performance impact is expected, as this change only modifies schema configuration.

## Security impact

Unknown. This change introduces an option for users to specify a custom schema for migration tables, which may impact security depending on how database permissions are configured.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.
