### PR TITLE
Add an option to terminate all existing connections to the database when resetting a database

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,8 @@ Options:
       --shadow  Applies migrations to shadow DB.      [boolean] [default: false]
       --erase   This is your double opt-in to make it clear this DELETES
                 EVERYTHING.                           [boolean] [default: false]
+      --force   Terminate all existing connections to the database.
+                                                      [boolean] [default: false]
 ```
 
 

--- a/__tests__/reset.test.ts
+++ b/__tests__/reset.test.ts
@@ -1,0 +1,62 @@
+import { _reset } from "../src/commands/reset";
+import { ParsedSettings, parseSettings } from "../src/settings";
+import { withClient } from "../src/pgReal";
+
+jest.mock("../src/commands/migrate");
+
+jest.mock("../src/pgReal", () => ({
+  withClient: jest.fn(),
+  escapeIdentifier: (id: string) => `"${id}"`,
+}));
+
+let parsedSettings: ParsedSettings;
+
+let mockPgClient: {
+  query: jest.Mock<any, any, any>;
+};
+
+describe("_reset", () => {
+  beforeEach(async () => {
+    parsedSettings = await parseSettings({
+      connectionString: "test_db",
+      rootConnectionString: "[rootConnectionString]",
+
+      placeholders: {
+        ":DATABASE_AUTHENTICATOR": "[DATABASE_AUTHENTICATOR]",
+        ":DATABASE_AUTHENTICATOR_PASSWORD": "[DATABASE_AUTHENTICATOR_PASSWORD]",
+      },
+      beforeReset: [],
+      beforeAllMigrations: [],
+      beforeCurrent: [],
+      afterReset: [],
+      afterAllMigrations: [],
+      afterCurrent: [],
+    });
+
+    mockPgClient = {
+      query: jest.fn(),
+    };
+
+    (withClient as any).mockImplementation(
+      async (_connString: any, _settings: any, callback: any) => {
+        await callback(mockPgClient);
+      },
+    );
+  });
+
+  it("calls DROP DATABASE without FORCE when force is false", async () => {
+    await _reset(parsedSettings, false, false);
+
+    expect(mockPgClient.query).toHaveBeenCalledWith(
+      'DROP DATABASE IF EXISTS "test_db";',
+    );
+  });
+
+  it("calls DROP DATABASE with FORCE when force is true", async () => {
+    await _reset(parsedSettings, false, true);
+
+    expect(mockPgClient.query).toHaveBeenCalledWith(
+      'DROP DATABASE IF EXISTS "test_db" WITH (FORCE);',
+    );
+  });
+});

--- a/src/commands/commit.ts
+++ b/src/commands/commit.ts
@@ -95,7 +95,7 @@ export async function _commit(
     Message: message ? message : undefined,
     ...omit(headers, ["Previous", "Hash", "Message"]),
   });
-  await _reset(parsedSettings, true);
+  await _reset(parsedSettings, true, false);
   const newMigrationFilepath = `${committedMigrationsFolder}/${newMigrationFilename}`;
   await fsp.writeFile(newMigrationFilepath, finalBody);
   await fsp.chmod(newMigrationFilepath, "440");

--- a/src/commands/uncommit.ts
+++ b/src/commands/uncommit.ts
@@ -56,7 +56,7 @@ export async function _uncommit(parsedSettings: ParsedSettings): Promise<void> {
   );
 
   // Reset shadow
-  await _reset(parsedSettings, true);
+  await _reset(parsedSettings, true, false);
   await _migrate(parsedSettings, true, true);
 }
 


### PR DESCRIPTION
## Description

This PR introduces a new `--force` option for the `graphile-migrate reset` command, which allows terminating existing connections to the database when dropping it.

I often face a case during end-to-end testing when before each test case I want to reset the database. Unfortunately due to some lingering connections from previous tests, the `graphile-migrate reset` command sometimes throws an error as expected. This change allows to bypass that limitation.

## Performance impact

Unknown.

## Security impact

Unknown.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [x] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.