### PR TITLE
Compile and run will both replace includes now.

### DIFF
--- a/README.md
+++ b/README.md
@@ -768,8 +768,9 @@ drop policy if exists access_by_numbers on mytable;
 create policy access_by_numbers on mytable for update using (myfunction(4, 2) < 42);
 ```
 
-and when the migration is committed or watched, the contents of `myfunction.sql`
-will be included in the result, such that the following SQL is executed:
+and when the migration is committed, watched, run, or compiled, the contents of
+`myfunction.sql` will be included in the result, such that the following SQL is
+executed:
 
 ```sql
 create or replace function myfunction(a int, b int)

--- a/README.md
+++ b/README.md
@@ -218,22 +218,23 @@ Commands:
   graphile-migrate reset           Drops and re-creates the database, re-running
                                    all committed migrations from the start.
                                    **HIGHLY DESTRUCTIVE**.
-  graphile-migrate compile [file]  Compiles a SQL file, inserting all the
-                                   placeholders and returning the result to
-                                   STDOUT
-  graphile-migrate run [file]      Compiles a SQL file, inserting all the
-                                   placeholders, and then runs it against the
-                                   database. Useful for seeding. If called from
-                                   an action will automatically run against the
-                                   same database (via GM_DBURL envvar) unless
-                                   --shadow or --rootDatabase are supplied.
+  graphile-migrate compile [file]  Compiles a SQL file (resolving `--!includes`,
+                                   replacing :PLACEHOLDERs, etc) and outputs the
+                                   result to STDOUT
+  graphile-migrate run [file]      Compiles a SQL file (resolving `--!includes`,
+                                   replacing :PLACEHOLDERs, etc) and then runs
+                                   it against the database. Useful for seeding.
+                                   If called from an action will automatically
+                                   run against the same database (via GM_DBURL
+                                   envvar) unless --shadow or --rootDatabase are
+                                   supplied.
   graphile-migrate completion      Generate shell completion script.
 
 Options:
       --help    Show help                                              [boolean]
   -c, --config  Optional path to gmrc file   [string] [default: .gmrc[.js|.cjs]]
 
-You are running graphile-migrate v2.0.0-rc.1.
+You are running graphile-migrate v2.0.0-rc.2.
 ```
 
 
@@ -374,8 +375,8 @@ Options:
 ```
 graphile-migrate compile [file]
 
-Compiles a SQL file, inserting all the placeholders and returning the result to
-STDOUT
+Compiles a SQL file (resolving `--!includes`, replacing :PLACEHOLDERs, etc) and
+outputs the result to STDOUT
 
 Options:
       --help    Show help                                              [boolean]
@@ -390,10 +391,10 @@ Options:
 ```
 graphile-migrate run [file]
 
-Compiles a SQL file, inserting all the placeholders, and then runs it against
-the database. Useful for seeding. If called from an action will automatically
-run against the same database (via GM_DBURL envvar) unless --shadow or
---rootDatabase are supplied.
+Compiles a SQL file (resolving `--!includes`, replacing :PLACEHOLDERs, etc) and
+then runs it against the database. Useful for seeding. If called from an action
+will automatically run against the same database (via GM_DBURL envvar) unless
+--shadow or --rootDatabase are supplied.
 
 Options:
       --help          Show help                                        [boolean]

--- a/__tests__/compile.test.ts
+++ b/__tests__/compile.test.ts
@@ -39,7 +39,6 @@ CREATE EXTENSION IF NOT EXISTS citext WITH SCHEMA public;
 CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA public;
 COMMIT;
 `,
-      "stdin",
     ),
   ).toEqual(`\
 BEGIN;
@@ -68,7 +67,7 @@ select 1;
 --!include foo.sql
 select 2;
 `,
-      `${process.cwd()}/migrations/current.sql`,
+      { filename: `${process.cwd()}/migrations/current.sql` },
     ),
   ).toEqual(`\
 select 1;

--- a/__tests__/compile.test.ts
+++ b/__tests__/compile.test.ts
@@ -64,11 +64,15 @@ it("will compile included files", async () => {
     await compile(
       settings,
       `\
+select 1;
 --!include foo.sql
+select 2;
 `,
       `${process.cwd()}/migrations/current.sql`,
     ),
   ).toEqual(`\
+select 1;
 select * from foo;
+select 2;
 `);
 });

--- a/__tests__/compile.test.ts
+++ b/__tests__/compile.test.ts
@@ -2,18 +2,17 @@ import "./helpers";
 
 import mockFs from "mock-fs";
 
-import { compile, Settings } from "../src";
+import { compile } from "../src";
 let old: string | undefined;
-let settings: Settings;
-beforeAll(async () => {
+const settings = {
+  connectionString: "postgres://dbowner:dbpassword@dbhost:1221/dbname",
+  placeholders: {
+    ":DATABASE_AUTHENTICATOR": "!ENV",
+  },
+};
+beforeAll(() => {
   old = process.env.DATABASE_AUTHENTICATOR;
   process.env.DATABASE_AUTHENTICATOR = "dbauth";
-  settings = {
-    connectionString: "postgres://dbowner:dbpassword@dbhost:1221/dbname",
-    placeholders: {
-      ":DATABASE_AUTHENTICATOR": "!ENV",
-    },
-  };
 });
 afterAll(() => {
   process.env.DATABASE_AUTHENTICATOR = old;

--- a/src/commands/_common.ts
+++ b/src/commands/_common.ts
@@ -119,6 +119,23 @@ export async function getSettings(options: Options = {}): Promise<Settings> {
   }
 }
 
+export async function readFileOrStdin(file: unknown): Promise<{
+  filename: string;
+  content: string;
+}> {
+  if (file != null) {
+    if (typeof file === "string") {
+      const filename = resolve(file);
+      const content = await fsp.readFile(filename, "utf8");
+      return { filename, content };
+    } else {
+      throw new Error(`Unexpected value for "file" flag`);
+    }
+  } else {
+    return { filename: "stdin", content: await readStdin() };
+  }
+}
+
 export function readStdin(): Promise<string> {
   return new Promise((resolve, reject) => {
     let data = "";

--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -39,7 +39,7 @@ export const compileCommand: CommandModule<
   command: "compile [file]",
   aliases: [],
   describe: `\
-Compiles a SQL file, resolving includes, inserting all the placeholders and returning the result to STDOUT`,
+Compiles a SQL file (resolving \`--!includes\`, replacing :PLACEHOLDERs, etc) and outputs the result to STDOUT`,
   builder: {
     shadow: {
       type: "boolean",

--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -22,7 +22,7 @@ export async function compile(
   rawContent: string,
   options: boolean | CompileOptions = false,
 ): Promise<string> {
-  const { shadow = false, filename = "stdin" } = resolveOptions(options);
+  const { shadow = false, filename = "unknown" } = resolveOptions(options);
   const parsedSettings = await parseSettings(settings, shadow);
   const content = await compileIncludes(
     parsedSettings,

--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -1,10 +1,8 @@
-import * as fsp from "fs/promises";
-import { resolve } from "path";
-import { ArgumentsCamelCase, CommandModule } from "yargs";
+import { CommandModule } from "yargs";
 
 import { compileIncludes, compilePlaceholders } from "../migration";
 import { parseSettings, Settings } from "../settings";
-import { CommonArgv, getSettings, readStdin } from "./_common";
+import { CommonArgv, getSettings, readFileOrStdin } from "./_common";
 
 interface CompileArgv extends CommonArgv {
   shadow?: boolean;
@@ -34,20 +32,6 @@ export async function compile(
   return compilePlaceholders(parsedSettings, content, shadow);
 }
 
-async function readInput(argv: ArgumentsCamelCase<CompileArgv>) {
-  if (argv.file != null) {
-    if (typeof argv.file === "string") {
-      const filename = resolve(argv.file);
-      const content = await fsp.readFile(filename, "utf8");
-      return { filename, content };
-    } else {
-      throw new Error(`Unexpected value for "file" flag`);
-    }
-  } else {
-    return { filename: "stdin", content: await readStdin() };
-  }
-}
-
 export const compileCommand: CommandModule<
   Record<string, never>,
   CompileArgv
@@ -65,7 +49,7 @@ Compiles a SQL file, resolving includes, inserting all the placeholders and retu
   },
   handler: async (argv) => {
     const settings = await getSettings({ configFile: argv.config });
-    const { content, filename } = await readInput(argv);
+    const { content, filename } = await readFileOrStdin(argv.file);
     const compiled = await compile(settings, content, {
       shadow: argv.shadow,
       filename,

--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -1,6 +1,6 @@
 import * as fsp from "fs/promises";
 import { resolve } from "path";
-import { CommandModule } from "yargs";
+import { ArgumentsCamelCase, CommandModule } from "yargs";
 
 import { compileIncludes, compilePlaceholders } from "../migration";
 import { parseSettings, Settings } from "../settings";
@@ -25,6 +25,20 @@ export async function compile(
   return compilePlaceholders(parsedSettings, parsedContent, shadow);
 }
 
+async function readInput(argv: ArgumentsCamelCase<CompileArgv>) {
+  if (argv.file != null) {
+    if (typeof argv.file === "string") {
+      const filename = resolve(argv.file);
+      const content = await fsp.readFile(filename, "utf8");
+      return { filename, content };
+    } else {
+      throw new Error(`Unexpected value for "file" flag`);
+    }
+  } else {
+    return { filename: "stdin", content: await readStdin() };
+  }
+}
+
 export const compileCommand: CommandModule<
   Record<string, never>,
   CompileArgv
@@ -42,14 +56,7 @@ Compiles a SQL file, resolving includes, inserting all the placeholders and retu
   },
   handler: async (argv) => {
     const settings = await getSettings({ configFile: argv.config });
-    const { content, filename } =
-      typeof argv.file === "string"
-        ? {
-            filename: resolve(argv.file),
-            content: await fsp.readFile(argv.file, "utf8"),
-          }
-        : { filename: "stdin", content: await readStdin() };
-
+    const { content, filename } = await readInput(argv);
     const compiled = await compile(settings, content, filename, argv.shadow);
 
     // eslint-disable-next-line no-console

--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -10,19 +10,28 @@ interface CompileArgv extends CommonArgv {
   shadow?: boolean;
 }
 
+interface CompileOptions {
+  shadow?: boolean;
+  filename?: string;
+}
+
+function resolveOptions(options: CompileOptions | boolean) {
+  return typeof options === "boolean" ? { shadow: options } : options;
+}
+
 export async function compile(
   settings: Settings,
-  content: string,
-  filename: string,
-  shadow = false,
+  rawContent: string,
+  options: boolean | CompileOptions = false,
 ): Promise<string> {
+  const { shadow = false, filename = "stdin" } = resolveOptions(options);
   const parsedSettings = await parseSettings(settings, shadow);
-  const parsedContent = await compileIncludes(
+  const content = await compileIncludes(
     parsedSettings,
-    content,
+    rawContent,
     new Set([filename]),
   );
-  return compilePlaceholders(parsedSettings, parsedContent, shadow);
+  return compilePlaceholders(parsedSettings, content, shadow);
 }
 
 async function readInput(argv: ArgumentsCamelCase<CompileArgv>) {
@@ -57,8 +66,10 @@ Compiles a SQL file, resolving includes, inserting all the placeholders and retu
   handler: async (argv) => {
     const settings = await getSettings({ configFile: argv.config });
     const { content, filename } = await readInput(argv);
-    const compiled = await compile(settings, content, filename, argv.shadow);
-
+    const compiled = await compile(settings, content, {
+      shadow: argv.shadow,
+      filename,
+    });
     // eslint-disable-next-line no-console
     console.log(compiled);
   },

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -23,7 +23,7 @@ interface RunArgv extends CommonArgv {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function run<T extends QueryResultRow = QueryResultRow>(
   settings: Settings,
-  content: string,
+  rawContent: string,
   filename: string,
   {
     shadow = false,
@@ -36,12 +36,12 @@ export async function run<T extends QueryResultRow = QueryResultRow>(
   } = {},
 ): Promise<T[] | undefined> {
   const parsedSettings = await parseSettings(settings, shadow);
-  const parsedContent = await compileIncludes(
+  const content = await compileIncludes(
     parsedSettings,
-    content,
+    rawContent,
     new Set([filename]),
   );
-  const sql = compilePlaceholders(parsedSettings, parsedContent, shadow);
+  const sql = compilePlaceholders(parsedSettings, content, shadow);
   const baseConnectionString = rootDatabase
     ? parsedSettings.rootConnectionString
     : shadow

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,5 +1,3 @@
-import * as fsp from "fs/promises";
-import { resolve } from "path";
 import { QueryResultRow } from "pg";
 import { CommandModule } from "yargs";
 
@@ -12,7 +10,8 @@ import {
   parseSettings,
   Settings,
 } from "../settings";
-import { CommonArgv, getDatabaseName, getSettings, readStdin } from "./_common";
+import type { CommonArgv } from "./_common";
+import { getDatabaseName, getSettings, readFileOrStdin } from "./_common";
 
 interface RunArgv extends CommonArgv {
   shadow?: boolean;
@@ -108,14 +107,7 @@ Compiles a SQL file, resolving includes, inserting all the placeholders, and the
             connectionString: process.env.GM_DBURL,
           };
 
-    const { content, filename } =
-      typeof argv.file === "string"
-        ? {
-            filename: resolve(argv.file),
-            content: await fsp.readFile(argv.file, "utf8"),
-          }
-        : { filename: "stdin", content: await readStdin() };
-
+    const { content, filename } = await readFileOrStdin(argv.file);
     const rows = await run(settings, content, filename, argv);
 
     if (rows) {

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -67,7 +67,7 @@ export const runCommand: CommandModule<Record<string, never>, RunArgv> = {
   command: "run [file]",
   aliases: [],
   describe: `\
-Compiles a SQL file, resolving includes, inserting all the placeholders, and then runs it against the database. Useful for seeding. If called from an action will automatically run against the same database (via GM_DBURL envvar) unless --shadow or --rootDatabase are supplied.`,
+Compiles a SQL file (resolving \`--!includes\`, replacing :PLACEHOLDERs, etc) and then runs it against the database. Useful for seeding. If called from an action will automatically run against the same database (via GM_DBURL envvar) unless --shadow or --rootDatabase are supplied.`,
   builder: {
     shadow: {
       type: "boolean",


### PR DESCRIPTION
## Description

- Closes https://github.com/graphile/migrate/issues/217 

There was already a PR for this, https://github.com/graphile/migrate/pull/235, but rather than go two steps removed to get this across the finish line I just forked the up to date repo and made sure to add tests, address the feedback I saw on the other PR.

## Performance impact

## Security impact

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [x] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.


