### PR TITLE
feat: add --forceActions option to current

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,9 +302,13 @@ Runs any un-executed committed migrations, as well as the current migration. For
 development.
 
 Options:
-      --help    Show help                                              [boolean]
-  -c, --config  Optional path to gmrc file   [string] [default: .gmrc[.js|.cjs]]
-      --shadow  Apply migrations to the shadow DB (for development).
+      --help          Show help                                        [boolean]
+  -c, --config        Optional path to gmrc file
+                                             [string] [default: .gmrc[.js|.cjs]]
+      --shadow        Apply migrations to the shadow DB (for development).
+                                                      [boolean] [default: false]
+      --forceActions  Run beforeAllMigrations and afterAllMigrations actions
+                      even if no migration was necessary.
                                                       [boolean] [default: false]
 ```
 

--- a/README.md
+++ b/README.md
@@ -307,9 +307,9 @@ Options:
                                              [string] [default: .gmrc[.js|.cjs]]
       --shadow        Apply migrations to the shadow DB (for development).
                                                       [boolean] [default: false]
-      --forceActions  Run beforeAllMigrations and afterAllMigrations actions
-                      even if no migration was necessary.
-                                                      [boolean] [default: false]
+      --forceActions  Run beforeAllMigrations, afterAllMigrations,
+                      beforeCurrent, and afterCurrent actions even if no
+                      migration was necessary.        [boolean] [default: false]
 ```
 
 

--- a/__tests__/current.test.ts
+++ b/__tests__/current.test.ts
@@ -1,10 +1,12 @@
+jest.mock("child_process");
 import "./helpers"; // Has side-effects; must come first
 
+import { exec } from "child_process";
 import mockFs from "mock-fs";
 
 import { current } from "../src";
 import { withClient } from "../src/pg";
-import { ParsedSettings, parseSettings } from "../src/settings";
+import { ParsedSettings, parseSettings, Settings } from "../src/settings";
 import { makeMigrations, resetDb, settings } from "./helpers";
 
 beforeEach(resetDb);
@@ -133,4 +135,70 @@ it("runs migrations", async () => {
   `);
   expect(newTables).toEqual(tables);
   expect(newEnums).toEqual(enums);
+});
+
+it("runs actions when forceActions is set", async () => {
+  const ACTIONS = {
+    initial: {
+      forceActions: false,
+      currentSql: "",
+      expectedActions: [
+        "beforeAllMigrations",
+        "afterAllMigrations",
+        "beforeCurrent",
+        "afterCurrent",
+      ],
+    },
+    currentChange: {
+      forceActions: false,
+      currentSql: MIGRATION_NOTRX_TEXT,
+      expectedActions: ["beforeCurrent", "afterCurrent"],
+    },
+    noop: {
+      forceActions: false,
+      currentSql: MIGRATION_NOTRX_TEXT,
+      expectedActions: [],
+    },
+    forceActions: {
+      forceActions: true,
+      currentSql: MIGRATION_NOTRX_TEXT,
+      expectedActions: [
+        "beforeAllMigrations",
+        "afterAllMigrations",
+        "beforeCurrent",
+        "afterCurrent",
+      ],
+    },
+  } as const;
+  const settingsWithHooks: Settings = {
+    ...settings,
+    beforeAllMigrations: [
+      { _: "command", command: "echo did_beforeAllMigrations" },
+    ],
+    afterAllMigrations: [
+      { _: "command", command: "echo did_afterAllMigrations" },
+    ],
+    beforeCurrent: [{ _: "command", command: "echo did_beforeCurrent" }],
+    afterCurrent: [{ _: "command", command: "echo did_afterCurrent" }],
+  };
+  for (const mode of Object.keys(ACTIONS) as Array<keyof typeof ACTIONS>) {
+    const { forceActions, currentSql, expectedActions } = ACTIONS[mode];
+
+    mockFs({
+      [`migrations/committed/000001.sql`]: MIGRATION_1_COMMITTED,
+      [`migrations/committed/000002.sql`]: MIGRATION_ENUM_COMMITTED, // Creates enum with 1 value
+      "migrations/current.sql": currentSql,
+    });
+
+    const mockedExec: jest.Mock<typeof exec> = exec as any;
+    mockedExec.mockClear();
+    mockedExec.mockImplementation((_cmd, _options, callback) =>
+      callback(null, { stdout: "", stderr: "" }),
+    );
+    await current(settingsWithHooks, { forceActions });
+    const calledActions = mockedExec.mock.calls.map((c) =>
+      c[0].substring("echo did_".length),
+    );
+    expect(calledActions).toEqual(expectedActions);
+  }
 });

--- a/src/commands/current.ts
+++ b/src/commands/current.ts
@@ -18,7 +18,7 @@ export async function current(
 ): Promise<void> {
   const { shadow = false, forceActions = false } = options;
   const parsedSettings = await parseSettings(settings, shadow);
-  await _migrate(parsedSettings, shadow);
+  await _migrate(parsedSettings, shadow, forceActions);
 
   const currentLocation = await getCurrentMigrationLocation(parsedSettings);
   if (!currentLocation.exists) {
@@ -55,7 +55,7 @@ export const currentCommand: CommandModule<
       type: "boolean",
       default: false,
       description:
-        "Run beforeAllMigrations and afterAllMigrations actions even if no migration was necessary.",
+        "Run beforeAllMigrations, afterAllMigrations, beforeCurrent, and afterCurrent actions even if no migration was necessary.",
     },
   },
   handler: async (argv) => {

--- a/src/commands/current.ts
+++ b/src/commands/current.ts
@@ -9,13 +9,14 @@ import { _migrate } from "./migrate";
 
 interface CurrentArgv extends CommonArgv {
   shadow?: boolean;
+  forceActions?: boolean;
 }
 
 export async function current(
   settings: Settings,
   options: Partial<CurrentArgv> = {},
 ): Promise<void> {
-  const { shadow = false } = options;
+  const { shadow = false, forceActions = false } = options;
   const parsedSettings = await parseSettings(settings, shadow);
   await _migrate(parsedSettings, shadow);
 
@@ -31,6 +32,7 @@ export async function current(
   const run = makeCurrentMigrationRunner(parsedSettings, {
     once: true,
     shadow,
+    forceActions,
   });
   return run();
 }
@@ -48,6 +50,12 @@ export const currentCommand: CommandModule<
       type: "boolean",
       default: false,
       description: "Apply migrations to the shadow DB (for development).",
+    },
+    forceActions: {
+      type: "boolean",
+      default: false,
+      description:
+        "Run beforeAllMigrations and afterAllMigrations actions even if no migration was necessary.",
     },
   },
   handler: async (argv) => {

--- a/src/currentRunner.ts
+++ b/src/currentRunner.ts
@@ -13,9 +13,10 @@ export function makeCurrentMigrationRunner(
   options: {
     once?: boolean;
     shadow?: boolean;
+    forceActions?: boolean;
   } = {},
 ): () => Promise<void> {
-  const { shadow = false } = options;
+  const { shadow = false, forceActions = false } = options;
   async function run(): Promise<void> {
     const currentLocation = await getCurrentMigrationLocation(parsedSettings);
     const body = await readCurrentMigration(parsedSettings, currentLocation);
@@ -75,7 +76,7 @@ export function makeCurrentMigrationRunner(
               currentBodyMinified === previousBodyMinified;
 
             // 4: if different
-            if (!migrationsAreEquivalent) {
+            if (forceActions || !migrationsAreEquivalent) {
               await executeActions(
                 parsedSettings,
                 shadow,

--- a/src/currentRunner.ts
+++ b/src/currentRunner.ts
@@ -75,14 +75,17 @@ export function makeCurrentMigrationRunner(
             migrationsAreEquivalent =
               currentBodyMinified === previousBodyMinified;
 
-            // 4: if different
+            // 3a: Run actions if the migrations are different OR if forced.
             if (forceActions || !migrationsAreEquivalent) {
               await executeActions(
                 parsedSettings,
                 shadow,
                 parsedSettings.beforeCurrent,
               );
+            }
 
+            // 4: if different
+            if (!migrationsAreEquivalent) {
               // 4a: invert previous current; on success delete from graphile_migrate.current; on failure rollback and abort
               if (previousBody) {
                 await reverseMigration(lockingPgClient, previousBody);
@@ -136,7 +139,7 @@ export function makeCurrentMigrationRunner(
       );
       const interval = process.hrtime(start);
       const duration = interval[0] * 1e3 + interval[1] * 1e-6;
-      if (!migrationsAreEquivalent) {
+      if (forceActions || !migrationsAreEquivalent) {
         await executeActions(
           parsedSettings,
           shadow,


### PR DESCRIPTION
Implements https://github.com/graphile/migrate/pull/148; work was primarily done by @maxkorp 

## Description

This adds the `--forceActions` flag to `graphile-migrate current`, which behaves as it does for the `migrate` command

## Performance impact

If running `graphile-migrate current` this will run the actions as specified without any real performance hit (except for the time spent to run the actions, obviously), since it's just an additional or statement against a boolean. 

## Security impact

None that I can think of?

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [x] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.